### PR TITLE
Consider deleting non-existing device as success

### DIFF
--- a/push/apns.go
+++ b/push/apns.go
@@ -136,7 +136,7 @@ func (pusher *APNSPusher) recvFeedback() {
 		// push.Sender as NotificationService and bridge over the differences
 		// between gcm and apns on handling unregistered devices (probably
 		// as an async channel)
-		if err := conn.DeleteDeviceByToken(fb.DeviceToken, fb.Timestamp); err != nil {
+		if err := conn.DeleteDeviceByToken(fb.DeviceToken, fb.Timestamp); err != nil && err != skydb.ErrDeviceNotFound {
 			log.Errorf("apns/fb: failed to delete device token = %s: %v", fb.DeviceToken, err)
 		}
 	}


### PR DESCRIPTION
If we think deletion is an idempotent operation, then deleting non-existing device should be considered as success. It is because both result in a desired state, that is the device will no longer exist after the statement is executed.