### PR TITLE
Make the CORSHost default to `*`

### DIFF
--- a/skyconfig/config.go
+++ b/skyconfig/config.go
@@ -102,6 +102,7 @@ func NewConfiguration() Configuration {
 	config.App.Name = "myapp"
 	config.App.AccessControl = "role"
 	config.App.DevMode = true
+	config.App.CORSHost = "*"
 	config.DB.ImplName = "pq"
 	config.DB.Option = "postgres://postgres:@localhost/postgres?sslmode=disable"
 	config.TokenStore.ImplName = "fs"


### PR DESCRIPTION
Allowing all request from different domain is helpful for getting start to do
real work in development, while the user can always restrict the request on
production deployment.