### PR TITLE
Allow master key to bypass record ACL in query

### DIFF
--- a/handler/record.go
+++ b/handler/record.go
@@ -1007,9 +1007,10 @@ func queryResultInfo(db skydb.Database, query *skydb.Query, results *skydb.Rows)
 }
 
 type recordQueryPayload struct {
-	Query      skydb.Query
-	DatabaseID string
-	Userinfo   *skydb.UserInfo
+	Query                   skydb.Query
+	DatabaseID              string
+	Userinfo                *skydb.UserInfo
+	IgnorePublicDatabaseACL bool
 }
 
 func (payload *recordQueryPayload) Decode(data map[string]interface{}, parser *QueryParser) skyerr.Error {
@@ -1023,7 +1024,7 @@ func (payload *recordQueryPayload) Decode(data map[string]interface{}, parser *Q
 	}
 
 	payload.DatabaseID, _ = data["database_id"].(string)
-	if payload.DatabaseID == "_public" && payload.Userinfo != nil {
+	if payload.DatabaseID == "_public" && !payload.IgnorePublicDatabaseACL && payload.Userinfo != nil {
 		payload.Query.ReadableBy = *payload.Userinfo
 	}
 	return payload.Validate()
@@ -1073,7 +1074,8 @@ func (h *RecordQueryHandler) GetPreprocessors() []router.Processor {
 
 func (h *RecordQueryHandler) Handle(payload *router.Payload, response *router.Response) {
 	p := &recordQueryPayload{
-		Userinfo: payload.UserInfo,
+		Userinfo:                payload.UserInfo,
+		IgnorePublicDatabaseACL: payload.HasMasterKey(),
 	}
 	parser := QueryParser{UserID: payload.UserInfoID}
 	skyErr := p.Decode(payload.Data, &parser)

--- a/handler/record_test.go
+++ b/handler/record_test.go
@@ -1141,6 +1141,59 @@ func TestRecordQuery(t *testing.T) {
 
 			So(response.Err, ShouldNotBeNil)
 		})
+
+		Convey("Queries records without master key", func() {
+			userInfo := skydb.UserInfo{
+				ID: "ownerID",
+			}
+			payload := router.Payload{
+				Data: map[string]interface{}{
+					"record_type": "note",
+					"database_id": "_public",
+				},
+				UserInfoID: userInfo.ID,
+				UserInfo:   &userInfo,
+				AccessKey:  router.ClientAccessKey,
+				Database:   db,
+			}
+			response := router.Response{}
+
+			handler := &RecordQueryHandler{}
+			handler.Handle(&payload, &response)
+
+			So(response.Err, ShouldBeNil)
+			So(db.lastquery, ShouldResemble, &skydb.Query{
+				Type:       "note",
+				ReadableBy: userInfo,
+			})
+		})
+
+		Convey("Queries records with master key", func() {
+			userInfo := skydb.UserInfo{
+				ID: "ownerID",
+			}
+			payload := router.Payload{
+				Data: map[string]interface{}{
+					"record_type": "note",
+					"database_id": "_public",
+				},
+				UserInfoID: userInfo.ID,
+				UserInfo:   &userInfo,
+				AccessKey:  router.MasterAccessKey,
+				Database:   db,
+			}
+			response := router.Response{}
+
+			handler := &RecordQueryHandler{}
+			handler.Handle(&payload, &response)
+
+			So(response.Err, ShouldBeNil)
+			So(db.lastquery, ShouldResemble, &skydb.Query{
+				Type:       "note",
+				ReadableBy: skydb.UserInfo{},
+			})
+		})
+
 	})
 }
 


### PR DESCRIPTION
The was work earlier (#22) that bypass ACL when used with master key,
but that work only apply when saving, deleting and fetching
records. The query action still enforce ACL though.

This commit leave skydb.Query.ReadableBy as empty struct
when the request is authenticated with a master key.

connects #51