### PR TITLE
Use HTTP/2 APNS protocol

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,13 @@
 {
-	"ImportPath": "github.com/SkygearIO/skygear-server",
-	"GoVersion": "go1.5",
+	"ImportPath": "github.com/skygeario/skygear-server",
+	"GoVersion": "go1.6",
+	"GodepVersion": "v74",
 	"Deps": [
+		{
+			"ImportPath": "github.com/RobotsAndPencils/buford/push",
+			"Comment": "v0.10.0",
+			"Rev": "2d03c359eab35051daee2c71485309361639bed1"
+		},
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
 			"Comment": "v0.9.0-13-g74bde9e",
@@ -107,10 +113,6 @@
 			"Rev": "67823cd24dece1b04cced3a0a0b3ca2bc84d875e"
 		},
 		{
-			"ImportPath": "github.com/timehop/apns",
-			"Rev": "02b971829dfca0436e051a28d60f11ffec5e3516"
-		},
-		{
 			"ImportPath": "github.com/twinj/uuid",
 			"Rev": "70cac2bcd273ef6a371bb96cde363d28b68734c3"
 		},
@@ -128,7 +130,19 @@
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",
-			"Rev": "db8e4de5b2d6653f66aea53094624468caad15d2"
+			"Rev": "b400c2eff1badec7022a8c8f5bea058b6315eed7"
+		},
+		{
+			"ImportPath": "golang.org/x/net/http2",
+			"Rev": "b400c2eff1badec7022a8c8f5bea058b6315eed7"
+		},
+		{
+			"ImportPath": "golang.org/x/net/http2/hpack",
+			"Rev": "b400c2eff1badec7022a8c8f5bea058b6315eed7"
+		},
+		{
+			"ImportPath": "golang.org/x/net/lex/httplex",
+			"Rev": "b400c2eff1badec7022a8c8f5bea058b6315eed7"
 		},
 		{
 			"ImportPath": "golang.org/x/sys/unix",

--- a/main.go
+++ b/main.go
@@ -355,7 +355,6 @@ func initAPNSPusher(config skyconfig.Configuration, connOpener func() (skydb.Con
 		log.Fatalf("Failed to set up push sender: %v", err)
 	}
 	go apnsPushSender.Run()
-	go apnsPushSender.RunFeedback()
 
 	return apnsPushSender
 }

--- a/push/apns.go
+++ b/push/apns.go
@@ -207,7 +207,7 @@ func (pusher *APNSPusher) unregisterDevice(deviceToken string, timestamp time.Ti
 		}
 	}()
 
-	if err := pusher.conn.DeleteDeviceByToken(deviceToken, timestamp); err != nil && err != skydb.ErrDeviceNotFound {
+	if err := pusher.conn.DeleteDevicesByToken(deviceToken, timestamp); err != nil && err != skydb.ErrDeviceNotFound {
 		logger.Errorf("apns/fb: failed to delete device token = %s: %v", deviceToken, err)
 		return
 	}

--- a/push/apns_test.go
+++ b/push/apns_test.go
@@ -15,6 +15,7 @@
 package push
 
 import (
+	"crypto/tls"
 	"errors"
 	"net/http"
 	"testing"
@@ -24,7 +25,6 @@ import (
 	"github.com/skygeario/skygear-server/skydb"
 	. "github.com/skygeario/skygear-server/skytest"
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/timehop/apns"
 )
 
 type naiveServiceNotification struct {
@@ -187,12 +187,6 @@ func (c *mockConn) Open() (skydb.Conn, error) {
 	return c, nil
 }
 
-type feedbackChannel chan apns.FeedbackTuple
-
-func (ch feedbackChannel) Receive() <-chan apns.FeedbackTuple {
-	return ch
-}
-
 func TestAPNSFeedback(t *testing.T) {
 	Convey("APNSPusher", t, func() {
 		conn := &mockConn{}
@@ -252,5 +246,60 @@ func TestAPNSFeedback(t *testing.T) {
 				{"devicetoken1", time.Date(2046, 1, 2, 15, 4, 5, 0, time.UTC)},
 			})
 		})
+	})
+}
+
+func TestAPNSCertificate(t *testing.T) {
+	APNSCert := []byte(`-----BEGIN CERTIFICATE-----
+MIICvjCCAaYCCQDrgz2ANVkBfTANBgkqhkiG9w0BAQsFADAhMR8wHQYKCZImiZPy
+LGQBAQwPY29tLmV4YW1wbGUuQXBwMB4XDTE2MDcwODA3NTAzN1oXDTE3MDcwODA3
+NTAzN1owITEfMB0GCgmSJomT8ixkAQEMD2NvbS5leGFtcGxlLkFwcDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAKd+cBNZ9lyKb81WGbNU4Vh4Z5TJB0tI
+V7m3Iohl0sd8zbUhL8ISXPpKnPvwo2DZScs6Y4hJsZxQenNm5ll4cFAgcNHbu0I6
+T1VzLSnxtpgvDOdxOBN5Nw1syKfzMUJw8o8RMtRt9cYVBwlKvOI92agFqZVYCIA3
+4T/531f/VejIFd8wzp8fLMS+A8dJ+Run9Z4r4KZu8VhtKUP8GAFZ0pt9PL4Rm4Rl
+/J/FZi5EmCE9Ms1RZoLuwO/IKPuGIY5rRi1c0kbYL3+QPxlkJa9DGW/61mDEkPkx
+l6MvrbBFQIDSRUVQ97a8RNk/5tBwsAnyyqYxx9i9wjudNCv5YQs/QL8CAwEAATAN
+BgkqhkiG9w0BAQsFAAOCAQEAb1mm4+6B+8YFqagAQ18I8EzOIHqrceDHj+v3PAh7
+jD+orKmbFnq6kbzEj9AHOp+A5EjSLIBIarXFJIsbRXenYwDLF+0dwFkXzzhLSsAO
+kvsTQPFaQC/h3mV8stx2SLxTDpWMPaaNCOlPkTmEtqXA3fes/1hF6TYalYO6kHe8
+47iuzxKNjgfjjYeK3o4ccFS0+29WVoU5t+wuZ0Ha27PPNOFHLvn9TI9A5L+8ujgr
+oyxSZaLz1oPX7aCcC847s+a73+K4V4QwdvKhxEN2McdZqv1h1Ha5zptt4kniBv6X
+OFCnXiurw3uY37eBckl/JR++IkUekyIq1EJ0vfWyW/mhPQ==
+-----END CERTIFICATE-----`)
+	APNSKey := []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAp35wE1n2XIpvzVYZs1ThWHhnlMkHS0hXubciiGXSx3zNtSEv
+whJc+kqc+/CjYNlJyzpjiEmxnFB6c2bmWXhwUCBw0du7QjpPVXMtKfG2mC8M53E4
+E3k3DWzIp/MxQnDyjxEy1G31xhUHCUq84j3ZqAWplVgIgDfhP/nfV/9V6MgV3zDO
+nx8sxL4Dx0n5G6f1nivgpm7xWG0pQ/wYAVnSm308vhGbhGX8n8VmLkSYIT0yzVFm
+gu7A78go+4YhjmtGLVzSRtgvf5A/GWQlr0MZb/rWYMSQ+TGXoy+tsEVAgNJFRVD3
+trxE2T/m0HCwCfLKpjHH2L3CO500K/lhCz9AvwIDAQABAoIBAQCgZYyee4BZjpkS
+YmmqOpaySlunN/wsM9MOnjoLtLbtIq87zdQWXc98QQeknQVYMb1hSUEXurrDnq4k
+5V2iQJwNn4Nq9KmW+pAOnIWbrUXW5vfMi7fPrjzyNkLR0ypRHiiqqSWsGMFMN8bN
+Ny0621Acf4+u3OcHInwq7/baJkL271g1m0hX/7TJ/nv+SlO00IkB6tm8iU0LWant
+4fSvhV2ULxa0fF5XXx74jqDFF+NzJ45XMUDbbe72RKpydMsdprqp4BgaV7fbtHIx
+xjG/9z6KqM3v0bMkJFV9BnmWzNe7vrI96dizVR3w3Yygul7sNC2iZfe17ulaXXKA
+n3X+PBTBAoGBANkwAMW+dQw9x/dDIQgfkg27I7qgANdYyri/lJ6+GvMdcCd4mzQ+
+UnJzhPNJyPZSUZeHOthShbHvBcoYNi4AwEcor2bXJI3+jW3/Wqbpq87+9x3Hkk69
+tkKvESKy8IABOTntFD3/VGFjYiLXVpg0huvkRSlSv70gMusmTMxisvWNAoGBAMVt
+Bx9IVkZ4uFl565WmigUuO8ICgHeRovCqeF3g0YBlS/x9Jznd9QkMYT0hy9cE4b7Z
+GRm89mEOUclWgdsibkyEdD1qOF6xF+fi4xKaes8Vc3vuuhg+UqpYvbIxKFAT81A2
+adyL6npDJDqQ0DcRjMng8V/77ktLOe/g9HFLX957AoGAOIlKai9eAMXEXBVZb+fn
++TMR5e7oySYP/2+/nGMYWNj87Ql0PXFLvQddQIegjJ55JtzI8K7qppr2AtmyoN8J
+Lnzky/yNQ3lUD6I9Ut3ZH5U3dsUQzPaNj2ZLK6ExAeFPqEiS0GC68m8QiMlNfWmP
+BbDyYANubikHmDbsHvhCZbECgYA0hx62/wsdcu8xt1OsHIRqfnOd2gaOSax9tg2S
+hMeZDtqZ0j7GkbypbKbOmhhfHEhn++FGzNUM2798/0xLnqyUJUW8NW/MGfhPVTmv
+cHSudnmkhs7ytlpOQpAuQhAExlodhGzEJmH7p7OS9YbAsCWybOwr6p7rX5eJsGO5
+ZSGb0wKBgQCvYtVVUGPBbmp94yoRgQjPj+iZtSjmVA9LaNoX+g4UWxKTU3y+r9kg
+SZVlxzxtvFvO+LcxmP6wBSX30HmhtIFLxmOyySl6BjfbtE0uFnIxxrKhb2L0gqoN
+g723fJntDb71I1IS31Vd2wqqpVB4kDp8OiPnPp8ats/cNUFk77Jhxw==
+-----END RSA PRIVATE KEY-----`)
+
+	Convey("find apns topic", t, func() {
+		certificate, err := tls.X509KeyPair(APNSCert, APNSKey)
+		So(err, ShouldBeNil)
+		topic, err := findDefaultAPNSTopic(certificate)
+		So(err, ShouldBeNil)
+		So(topic, ShouldEqual, "com.example.App")
 	})
 }

--- a/push/apns_test.go
+++ b/push/apns_test.go
@@ -178,7 +178,7 @@ type mockConn struct {
 	skydb.Conn
 }
 
-func (c *mockConn) DeleteDeviceByToken(token string, t time.Time) error {
+func (c *mockConn) DeleteDevicesByToken(token string, t time.Time) error {
 	c.calls = append(c.calls, deleteCall{token, t})
 	return c.err
 }

--- a/skydb/conn.go
+++ b/skydb/conn.go
@@ -31,7 +31,7 @@ var ErrUserNotFound = errors.New("skydb: UserInfo ID not found")
 var ErrRoleUpdatesFailed = errors.New("skydb: Update of user roles failed")
 
 // ErrDeviceNotFound is returned by Conn.GetDevice, Conn.DeleteDevice,
-// Conn.DeleteDeviceByToken and Conn.DeleteEmptyDevicesByTime, if the desired Device
+// Conn.DeleteDevicesByToken and Conn.DeleteEmptyDevicesByTime, if the desired Device
 // cannot be found in the current container
 var ErrDeviceNotFound = errors.New("skydb: Specific device not found")
 
@@ -39,7 +39,7 @@ var ErrDeviceNotFound = errors.New("skydb: Specific device not found")
 // operation modifies the database and the database is readonly.
 var ErrDatabaseIsReadOnly = errors.New("skydb: database is read only")
 
-// ZeroTime represent a zero time.Time. It is used in DeleteDeviceByToken and
+// ZeroTime represent a zero time.Time. It is used in DeleteDevicesByToken and
 // DeleteEmptyDevicesByTime to signify a Delete without time constraint.
 var ZeroTime = time.Time{}
 
@@ -134,11 +134,11 @@ type Conn interface {
 	SaveDevice(device *Device) error
 	DeleteDevice(id string) error
 
-	// DeleteDeviceByToken deletes device where its Token == token and
+	// DeleteDevicesByToken deletes device where its Token == token and
 	// LastRegisteredAt < t. If t == ZeroTime, LastRegisteredAt is not considered.
 	//
 	// If such device does not exist, ErrDeviceNotFound is returned.
-	DeleteDeviceByToken(token string, t time.Time) error
+	DeleteDevicesByToken(token string, t time.Time) error
 
 	// DeleteEmptyDevicesByTime deletes device where Token is empty and
 	// LastRegisteredAt < t. If t == ZeroTime, LastRegisteredAt is not considered.

--- a/skydb/mock_skydb/mock.go
+++ b/skydb/mock_skydb/mock.go
@@ -70,14 +70,14 @@ func (_mr *_MockConnRecorder) DeleteDevice(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDevice", arg0)
 }
 
-func (_m *MockConn) DeleteDeviceByToken(_param0 string, _param1 time.Time) error {
-	ret := _m.ctrl.Call(_m, "DeleteDeviceByToken", _param0, _param1)
+func (_m *MockConn) DeleteDevicesByToken(_param0 string, _param1 time.Time) error {
+	ret := _m.ctrl.Call(_m, "DeleteDevicesByToken", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockConnRecorder) DeleteDeviceByToken(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDeviceByToken", arg0, arg1)
+func (_mr *_MockConnRecorder) DeleteDevicesByToken(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDevicesByToken", arg0, arg1)
 }
 
 func (_m *MockConn) DeleteEmptyDevicesByTime(_param0 time.Time) error {

--- a/skydb/pq/device.go
+++ b/skydb/pq/device.go
@@ -125,7 +125,7 @@ func (c *conn) DeleteDevice(id string) error {
 	return nil
 }
 
-func (c *conn) DeleteDeviceByToken(token string, t time.Time) error {
+func (c *conn) DeleteDevicesByToken(token string, t time.Time) error {
 	builder := psql.Delete(c.tableName("_device")).
 		Where("token = ?", token)
 	if t != skydb.ZeroTime {
@@ -143,8 +143,6 @@ func (c *conn) DeleteDeviceByToken(token string, t time.Time) error {
 	}
 	if rowsAffected == 0 {
 		return skydb.ErrDeviceNotFound
-	} else if rowsAffected > 1 {
-		panic(fmt.Errorf("want 1 rows updated, got %v", rowsAffected))
 	}
 
 	return nil

--- a/skydb/pq/device_test.go
+++ b/skydb/pq/device_test.go
@@ -193,7 +193,7 @@ func TestDevice(t *testing.T) {
 			}
 			So(c.SaveDevice(&device), ShouldBeNil)
 
-			err := c.DeleteDeviceByToken("devicetoken", skydb.ZeroTime)
+			err := c.DeleteDevicesByToken("devicetoken", skydb.ZeroTime)
 			So(err, ShouldBeNil)
 
 			var count int
@@ -212,7 +212,7 @@ func TestDevice(t *testing.T) {
 			}
 			So(c.SaveDevice(&device), ShouldBeNil)
 
-			err := c.DeleteDeviceByToken("devicetoken", time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC))
+			err := c.DeleteDevicesByToken("devicetoken", time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC))
 			So(err, ShouldEqual, skydb.ErrDeviceNotFound)
 		})
 

--- a/skydb/skydbtest/skydbtest.go
+++ b/skydb/skydbtest/skydbtest.go
@@ -216,8 +216,8 @@ func (conn *MapConn) DeleteDevice(id string) error {
 	panic("not implemented")
 }
 
-// DeleteDeviceByToken is not implemented.
-func (conn *MapConn) DeleteDeviceByToken(token string, t time.Time) error {
+// DeleteDevicesByToken is not implemented.
+func (conn *MapConn) DeleteDevicesByToken(token string, t time.Time) error {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
This commit switch the underlying APNS library to
RobotsAndPencils/buford, which sends push notification to APNS
through HTTP/2 protocol. The new protocol provides immediate feedback
for each notification sent.

connects #47