### PR TITLE
Fix scan NULL token in QueryDevicesByUser

### DIFF
--- a/skydb/pq/device.go
+++ b/skydb/pq/device.go
@@ -62,16 +62,18 @@ func (c *conn) QueryDevicesByUser(user string) ([]skydb.Device, error) {
 	defer rows.Close()
 	results := []skydb.Device{}
 	for rows.Next() {
+		var nullToken sql.NullString
 		d := skydb.Device{}
 		if err := rows.Scan(
 			&d.ID,
 			&d.Type,
-			&d.Token,
+			&nullToken,
 			&d.UserInfoID,
 			&d.LastRegisteredAt); err != nil {
 
 			panic(err)
 		}
+		d.Token = nullToken.String
 		d.LastRegisteredAt = d.LastRegisteredAt.UTC()
 		results = append(results, d)
 	}

--- a/skydb/pq/device_test.go
+++ b/skydb/pq/device_test.go
@@ -302,13 +302,29 @@ func TestDevice(t *testing.T) {
 			}
 			So(c.SaveDevice(&device), ShouldBeNil)
 
+			device = skydb.Device{
+				ID:               "device2",
+				Type:             "android",
+				Token:            "",
+				UserInfoID:       "userid",
+				LastRegisteredAt: time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC),
+			}
+			So(c.SaveDevice(&device), ShouldBeNil)
+
 			devices, err := c.QueryDevicesByUser("userid")
 			So(err, ShouldBeNil)
-			So(len(devices), ShouldEqual, 1)
+			So(len(devices), ShouldEqual, 2)
 			So(devices[0], ShouldResemble, skydb.Device{
 				ID:               "device",
 				Type:             "ios",
 				Token:            "devicetoken",
+				UserInfoID:       "userid",
+				LastRegisteredAt: time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC),
+			})
+			So(devices[1], ShouldResemble, skydb.Device{
+				ID:               "device2",
+				Type:             "android",
+				Token:            "",
 				UserInfoID:       "userid",
 				LastRegisteredAt: time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC),
 			})


### PR DESCRIPTION
If `device` table contains device with NULL token, Scan will complain
 that it is not able to scan a NULL value to a type of string.

connects #33