### PR TITLE
Allow db connection to start new transaction

### DIFF
--- a/pkg/server/skydb/pq/txdb_test.go
+++ b/pkg/server/skydb/pq/txdb_test.go
@@ -116,22 +116,18 @@ func TestTxDB(t *testing.T) {
 			So(db.Rollback(), ShouldEqual, skydb.ErrDatabaseTxDidNotBegin)
 		})
 
-		Convey("Begin/Commit/Rollback on a Commit'ed db returns ErrDatabaseTxDone", func() {
+		Convey("New transaction can begin after commit", func() {
 			So(db.Begin(), ShouldBeNil)
 			So(db.Commit(), ShouldBeNil)
 
-			So(db.Begin(), ShouldEqual, skydb.ErrDatabaseTxDone)
-			So(db.Commit(), ShouldEqual, skydb.ErrDatabaseTxDone)
-			So(db.Rollback(), ShouldEqual, skydb.ErrDatabaseTxDone)
+			So(db.Begin(), ShouldEqual, nil)
 		})
 
-		Convey("Begin/Commit/Rollback on a Rollback'ed db returns ErrDatabaseTxDone", func() {
+		Convey("New transaction can begin after rollback", func() {
 			So(db.Begin(), ShouldBeNil)
 			So(db.Rollback(), ShouldBeNil)
 
-			So(db.Begin(), ShouldEqual, skydb.ErrDatabaseTxDone)
-			So(db.Commit(), ShouldEqual, skydb.ErrDatabaseTxDone)
-			So(db.Rollback(), ShouldEqual, skydb.ErrDatabaseTxDone)
+			So(db.Begin(), ShouldEqual, nil)
 		})
 	})
 }


### PR DESCRIPTION
Previous implementation does not allow connection to start
a new transaction after a previously committed or rolled back transaction.
This scenario is hit in auth:login using an auth provider because UserInfo
is updated after creating a new user.