### PR TITLE
Fix golint tests

### DIFF
--- a/pkg/server/plugin/exec/process_test.go
+++ b/pkg/server/plugin/exec/process_test.go
@@ -26,6 +26,7 @@ import (
 
 	skyplugin "github.com/skygeario/skygear-server/pkg/server/plugin"
 	"github.com/skygeario/skygear-server/pkg/server/plugin/common"
+	"github.com/skygeario/skygear-server/pkg/server/router"
 	"github.com/skygeario/skygear-server/pkg/server/skyconfig"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
@@ -181,7 +182,7 @@ func TestRun(t *testing.T) {
 				return []byte(`{"result": {}}`), nil
 			}
 
-			ctx := context.WithValue(context.Background(), "UserID", "user")
+			ctx := context.WithValue(context.Background(), router.UserIDContextKey, "user")
 			transport.RunLambda(ctx, "work", []byte{})
 			So(executed, ShouldBeTrue)
 		})
@@ -631,7 +632,7 @@ func TestRun(t *testing.T) {
 				return []byte(`{"result": {}}`), nil
 			}
 
-			ctx := context.WithValue(context.Background(), "UserID", "user")
+			ctx := context.WithValue(context.Background(), router.UserIDContextKey, "user")
 			transport.RunHook(ctx, "note_afterSave", &recordin, nil)
 			So(executed, ShouldBeTrue)
 		})

--- a/pkg/server/plugin/handler_test.go
+++ b/pkg/server/plugin/handler_test.go
@@ -68,7 +68,7 @@ func TestHandler(t *testing.T) {
 			&handler,
 			func(p *router.Payload) {
 				p.Context = context.Background()
-				p.Context = context.WithValue(p.Context, "hello", "world")
+				p.Context = context.WithValue(p.Context, HelloContextKey, "world")
 			},
 		)
 
@@ -81,7 +81,7 @@ func TestHandler(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, `{
 	"kind": "I can be anything"
 }`)
-			So(transport.lastContext.Value("hello"), ShouldEqual, "world")
+			So(transport.lastContext.Value(HelloContextKey), ShouldEqual, "world")
 		})
 
 	})

--- a/pkg/server/plugin/hook/hook_test.go
+++ b/pkg/server/plugin/hook/hook_test.go
@@ -23,6 +23,10 @@ import (
 	"golang.org/x/net/context"
 )
 
+type ContextKey string
+
+var HelloContextKey ContextKey = "hello"
+
 func TestHookRegistry(t *testing.T) {
 	Convey("Registry", t, func() {
 
@@ -30,7 +34,7 @@ func TestHookRegistry(t *testing.T) {
 		afterSave := hooktest.StackingHook{}
 		beforeDelete := hooktest.StackingHook{}
 		afterDelete := hooktest.StackingHook{}
-		ctx := context.WithValue(context.Background(), "hello", "world")
+		ctx := context.WithValue(context.Background(), HelloContextKey, "world")
 
 		registry := NewRegistry()
 
@@ -55,7 +59,7 @@ func TestHookRegistry(t *testing.T) {
 				registry.ExecuteHooks(ctx, BeforeSave, record, originalRecord)
 				So(beforeSave.Records, ShouldResemble, []*skydb.Record{record})
 				So(beforeSave.OriginalRecords, ShouldResemble, []*skydb.Record{originalRecord})
-				So(beforeSave.Context[0].Value("hello"), ShouldEqual, "world")
+				So(beforeSave.Context[0].Value(HelloContextKey), ShouldEqual, "world")
 				So(afterSave.Records, ShouldBeEmpty)
 				So(afterSave.OriginalRecords, ShouldBeEmpty)
 				So(beforeDelete.Records, ShouldBeEmpty)
@@ -68,7 +72,7 @@ func TestHookRegistry(t *testing.T) {
 				So(beforeSave.OriginalRecords, ShouldBeEmpty)
 				So(afterSave.Records, ShouldResemble, []*skydb.Record{record})
 				So(afterSave.OriginalRecords, ShouldResemble, []*skydb.Record{originalRecord})
-				So(afterSave.Context[0].Value("hello"), ShouldEqual, "world")
+				So(afterSave.Context[0].Value(HelloContextKey), ShouldEqual, "world")
 				So(beforeDelete.Records, ShouldBeEmpty)
 				So(afterDelete.Records, ShouldBeEmpty)
 			})
@@ -80,7 +84,7 @@ func TestHookRegistry(t *testing.T) {
 				So(afterSave.Records, ShouldBeEmpty)
 				So(afterSave.OriginalRecords, ShouldBeEmpty)
 				So(beforeDelete.Records, ShouldResemble, []*skydb.Record{record})
-				So(beforeDelete.Context[0].Value("hello"), ShouldEqual, "world")
+				So(beforeDelete.Context[0].Value(HelloContextKey), ShouldEqual, "world")
 				So(afterDelete.Records, ShouldBeEmpty)
 			})
 
@@ -92,7 +96,7 @@ func TestHookRegistry(t *testing.T) {
 				So(afterSave.OriginalRecords, ShouldBeEmpty)
 				So(beforeDelete.Records, ShouldBeEmpty)
 				So(afterDelete.Records, ShouldResemble, []*skydb.Record{record})
-				So(afterDelete.Context[0].Value("hello"), ShouldEqual, "world")
+				So(afterDelete.Context[0].Value(HelloContextKey), ShouldEqual, "world")
 			})
 		})
 
@@ -117,8 +121,8 @@ func TestHookRegistry(t *testing.T) {
 			So(hook2.Records, ShouldResemble, []*skydb.Record{record})
 			So(hook1.OriginalRecords, ShouldResemble, []*skydb.Record{originalRecord})
 			So(hook2.OriginalRecords, ShouldResemble, []*skydb.Record{originalRecord})
-			So(hook1.Context[0].Value("hello"), ShouldEqual, "world")
-			So(hook2.Context[0].Value("hello"), ShouldEqual, "world")
+			So(hook1.Context[0].Value(HelloContextKey), ShouldEqual, "world")
+			So(hook2.Context[0].Value(HelloContextKey), ShouldEqual, "world")
 		})
 
 		Convey("executes no hooks", func() {

--- a/pkg/server/plugin/http/http_test.go
+++ b/pkg/server/plugin/http/http_test.go
@@ -27,6 +27,7 @@ import (
 
 	skyplugin "github.com/skygeario/skygear-server/pkg/server/plugin"
 	"github.com/skygeario/skygear-server/pkg/server/plugin/common"
+	"github.com/skygeario/skygear-server/pkg/server/router"
 	"github.com/skygeario/skygear-server/pkg/server/skyconfig"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 	. "github.com/skygeario/skygear-server/pkg/server/skytest"
@@ -75,7 +76,7 @@ func TestRun(t *testing.T) {
 		})
 
 		Convey("run lambda", func() {
-			ctx := context.WithValue(context.Background(), "UserID", "user")
+			ctx := context.WithValue(context.Background(), router.UserIDContextKey, "user")
 			data := []byte(`{"data": "bye"}`)
 			httpmock.RegisterResponder("POST", "http://localhost:8000/op/john",
 				func(req *http.Request) (*http.Response, error) {
@@ -100,7 +101,7 @@ func TestRun(t *testing.T) {
 		})
 
 		Convey("run hook", func() {
-			ctx := context.WithValue(context.Background(), "UserID", "user")
+			ctx := context.WithValue(context.Background(), router.UserIDContextKey, "user")
 
 			recordin := skydb.Record{
 				ID:      skydb.NewRecordID("note", "id"),

--- a/pkg/server/plugin/lambda_test.go
+++ b/pkg/server/plugin/lambda_test.go
@@ -69,7 +69,7 @@ func TestLambdaHandler(t *testing.T) {
 		}
 		r := handlertest.NewSingleRouteRouter(&handler, func(p *router.Payload) {
 			p.Context = context.Background()
-			p.Context = context.WithValue(p.Context, "hello", "world")
+			p.Context = context.WithValue(p.Context, HelloContextKey, "world")
 		})
 
 		Convey("handle", func() {
@@ -79,7 +79,7 @@ func TestLambdaHandler(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, `{
 	"result": {"args":["bob"]}
 }`)
-			So(transport.lastContext.Value("hello"), ShouldEqual, "world")
+			So(transport.lastContext.Value(HelloContextKey), ShouldEqual, "world")
 		})
 
 	})
@@ -96,7 +96,7 @@ func TestLambdaHandler(t *testing.T) {
 		}
 		r := handlertest.NewSingleRouteRouter(&handler, func(p *router.Payload) {
 			p.Context = context.Background()
-			p.Context = context.WithValue(p.Context, "hello", "world")
+			p.Context = context.WithValue(p.Context, HelloContextKey, "world")
 		})
 
 		Convey("init", func() {
@@ -106,7 +106,7 @@ func TestLambdaHandler(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, `{
 	"error":{"code":10000,"message":"an error","name":"UnexpectedError"}
 }`)
-			So(transport.lastContext.Value("hello"), ShouldEqual, "world")
+			So(transport.lastContext.Value(HelloContextKey), ShouldEqual, "world")
 		})
 
 	})

--- a/pkg/server/plugin/plugin_test.go
+++ b/pkg/server/plugin/plugin_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/skygeario/skygear-server/pkg/server/skyconfig"
 )
 
+type ContextKey string
+
+var HelloContextKey ContextKey = "hello"
+
 type MockPluginReadyPreprocessor struct{}
 
 func (p MockPluginReadyPreprocessor) Preprocess(payload *router.Payload, response *router.Response) int {

--- a/pkg/server/plugin/transport.go
+++ b/pkg/server/plugin/transport.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"github.com/skygeario/skygear-server/pkg/server/router"
 	"github.com/skygeario/skygear-server/pkg/server/skyconfig"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 	"golang.org/x/net/context"
@@ -93,7 +94,7 @@ func ContextMap(ctx context.Context) map[string]interface{} {
 		return map[string]interface{}{}
 	}
 	pluginCtx := map[string]interface{}{}
-	if userID, ok := ctx.Value("UserID").(string); ok {
+	if userID, ok := ctx.Value(router.UserIDContextKey).(string); ok {
 		pluginCtx["user_id"] = userID
 	}
 	return pluginCtx

--- a/pkg/server/plugin/transport_test.go
+++ b/pkg/server/plugin/transport_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"golang.org/x/net/context"
 
+	"github.com/skygeario/skygear-server/pkg/server/router"
 	"github.com/skygeario/skygear-server/pkg/server/skyconfig"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 )
@@ -120,7 +121,7 @@ func TestContextMap(t *testing.T) {
 
 	Convey("UserID", t, func() {
 		ctx := context.Background()
-		ctx = context.WithValue(ctx, "UserID", "42")
+		ctx = context.WithValue(ctx, router.UserIDContextKey, "42")
 		So(ContextMap(ctx), ShouldResemble, map[string]interface{}{
 			"user_id": "42",
 		})

--- a/pkg/server/preprocessor/auth.go
+++ b/pkg/server/preprocessor/auth.go
@@ -99,7 +99,7 @@ func (p *UserAuthenticator) Preprocess(payload *router.Payload, response *router
 
 		payload.AppName = token.AppName
 		payload.UserInfoID = token.UserInfoID
-		payload.Context = context.WithValue(payload.Context, "UserID", token.UserInfoID)
+		payload.Context = context.WithValue(payload.Context, router.UserIDContextKey, token.UserInfoID)
 		payload.AccessToken = token
 		return http.StatusOK
 	}
@@ -114,7 +114,7 @@ func (p *UserAuthenticator) Preprocess(payload *router.Payload, response *router
 	if payload.HasMasterKey() {
 		if userID, ok := payload.Data["_user_id"].(string); ok {
 			payload.UserInfoID = userID
-			payload.Context = context.WithValue(payload.Context, "UserID", userID)
+			payload.Context = context.WithValue(payload.Context, router.UserIDContextKey, userID)
 		}
 	}
 

--- a/pkg/server/router/model.go
+++ b/pkg/server/router/model.go
@@ -26,6 +26,10 @@ import (
 	"golang.org/x/net/context"
 )
 
+type ContextKey string
+
+var UserIDContextKey ContextKey = "UserID"
+
 // HandlerFunc specifies the function signature of a request handler function
 type HandlerFunc func(*Payload, *Response)
 


### PR DESCRIPTION
golint now expects a variable of non basic type
as a key to context.WithValue.