### PR TITLE
Fix fast restart of skygear-server result on worker stale

### DIFF
--- a/pkg/server/plugin/zmq/broker_test.go
+++ b/pkg/server/plugin/zmq/broker_test.go
@@ -52,7 +52,7 @@ func bytesArray(ss ...string) (bs [][]byte) {
 	return
 }
 
-func TestBrokerEndToEnd(t *testing.T) {
+func TestBrokerSock(t *testing.T) {
 	const (
 		clientAddr = "inproc://client.test"
 		workerAddr = "inproc://worker.test"
@@ -195,12 +195,83 @@ func TestWorker(t *testing.T) {
 			q.Add(newWorker(address2))
 			So(q.Len(), ShouldEqual, 2)
 
-			// With the worker to time out
+			// Wait the worker to time out
 			time.Sleep((HeartbeatLiveness + 1) * HeartbeatInterval)
 			q.Add(newWorker(address3))
 			So(q.Len(), ShouldEqual, 3)
 			q.Purge()
 			So(q.Len(), ShouldEqual, 1)
+		})
+	})
+}
+func TestBrokerWorker(t *testing.T) {
+	const (
+		clientAddr = "inproc://server.test"
+		workerAddr = "inproc://plugin.test"
+	)
+	broker, err := NewBroker("", clientAddr, workerAddr)
+	if err != nil {
+		t.Fatalf("Failed to init broker: %v", err)
+	}
+	go broker.Run()
+
+	Convey("Test Broker with worker", t, func() {
+		Convey("receive Ready signal will register the worker", func() {
+			w := workerSock(t, "ready", workerAddr)
+			defer w.Destroy()
+			w.SendMessage(bytesArray(Ready))
+			<-broker.freshWorkers
+
+			So(broker.workers.Len(), ShouldEqual, 1)
+			w.SendMessage(bytesArray(Shutdown))
+		})
+
+		Convey("receive multiple Ready signal will register all workers", func() {
+			w1 := workerSock(t, "ready1", workerAddr)
+			defer w1.Destroy()
+			w1.SendMessage(bytesArray(Ready))
+			<-broker.freshWorkers
+			w2 := workerSock(t, "ready2", workerAddr)
+			defer w2.Destroy()
+			w2.SendMessage(bytesArray(Ready))
+			<-broker.freshWorkers
+
+			So(broker.workers.Len(), ShouldEqual, 2)
+			w1.SendMessage(bytesArray(Shutdown))
+			w2.SendMessage(bytesArray(Shutdown))
+		})
+
+		Convey("reveice Heartbeat without Reay will not register the worker", func() {
+			w := workerSock(t, "heartbeat", workerAddr)
+			defer w.Destroy()
+			w.SendMessage(bytesArray(Heartbeat))
+			// Wait the poller to get the message
+			time.Sleep(HeartbeatInterval)
+			So(broker.workers.Len(), ShouldEqual, 0)
+		})
+
+		Convey("send message from server to plugin", func() {
+			s := clientSock(t, "server", clientAddr)
+			defer s.Destroy()
+			w := workerSock(t, "worker", workerAddr)
+			w.SetRcvtimeo(heartbeatIntervalMS)
+			defer w.Destroy()
+			w.SendMessage(bytesArray(Ready))
+			<-broker.freshWorkers
+			w2 := workerSock(t, "worker2", workerAddr)
+			w2.SetRcvtimeo(heartbeatIntervalMS)
+			defer w2.Destroy()
+			w2.SendMessage(bytesArray(Ready))
+			<-broker.freshWorkers
+
+			So(broker.workers.Len(), ShouldEqual, 2)
+
+			s.SendMessage(bytesArray("from server"))
+			// Wait the poller to get the message
+			time.Sleep(HeartbeatInterval)
+			So(broker.workers.Len(), ShouldEqual, 1)
+			msg, _ := w2.RecvMessage()
+			So(msg[1], ShouldResemble, []byte("from server"))
 		})
 	})
 }


### PR DESCRIPTION
zmq broker don't accept non register plugin heartbeat. It will force the plugin
resend a proper Ready and go through the init process again.

refs #150