### PR TITLE
Better handling for unrecognized data type

### DIFF
--- a/.gogocyclo
+++ b/.gogocyclo
@@ -5,3 +5,4 @@ ignores = `pq`.(*database).remoteColumnTypes
 ignores = `skydb`.(Predicate).Validate
 ignores = `skyconv`.ParseLiteral
 ignores = `zmq`.(*Broker).Run
+ignores = `skyconv`.(*JSONRecord).MarshalJSON

--- a/pkg/server/handler/recordutil.go
+++ b/pkg/server/handler/recordutil.go
@@ -171,6 +171,8 @@ func removeRecordFieldTypeHints(r *skydb.Record) {
 		switch v.(type) {
 		case skydb.Sequence:
 			delete(r.Data, k)
+		case skydb.Unknown:
+			delete(r.Data, k)
 		}
 	}
 }
@@ -498,7 +500,7 @@ func deriveRecordSchema(m skydb.Data) skydb.RecordSchema {
 	schema := skydb.RecordSchema{}
 	log.Debugf("%v", m)
 	for key, value := range m {
-		switch value.(type) {
+		switch val := value.(type) {
 		default:
 			log.WithFields(logrus.Fields{
 				"key":   key,
@@ -543,6 +545,11 @@ func deriveRecordSchema(m skydb.Data) skydb.RecordSchema {
 		case skydb.Sequence:
 			schema[key] = skydb.FieldType{
 				Type: skydb.TypeSequence,
+			}
+		case skydb.Unknown:
+			schema[key] = skydb.FieldType{
+				Type:           skydb.TypeUnknown,
+				UnderlyingType: val.UnderlyingType,
 			}
 		case map[string]interface{}, []interface{}:
 			schema[key] = skydb.FieldType{

--- a/pkg/server/skydb/datatype_string.go
+++ b/pkg/server/skydb/datatype_string.go
@@ -4,9 +4,9 @@ package skydb
 
 import "fmt"
 
-const _DataType_name = "TypeStringTypeNumberTypeBooleanTypeJSONTypeReferenceTypeLocationTypeDateTimeTypeAssetTypeACLTypeIntegerTypeSequence"
+const _DataType_name = "TypeStringTypeNumberTypeBooleanTypeJSONTypeReferenceTypeLocationTypeDateTimeTypeAssetTypeACLTypeIntegerTypeSequenceTypeUnknown"
 
-var _DataType_index = [...]uint8{0, 10, 20, 31, 39, 52, 64, 76, 85, 92, 103, 115}
+var _DataType_index = [...]uint8{0, 10, 20, 31, 39, 52, 64, 76, 85, 92, 103, 115, 126}
 
 func (i DataType) String() string {
 	i -= 1

--- a/pkg/server/skydb/pq/schema.go
+++ b/pkg/server/skydb/pq/schema.go
@@ -334,13 +334,14 @@ WHERE a.attrelid = $1 AND a.attnum > 0 AND NOT a.attisdropped`,
 
 	var columnName, pqType string
 	var integerColumns = []string{}
-	var columnErrors []error
 	for rows.Next() {
 		if err := rows.Scan(&columnName, &pqType); err != nil {
 			return nil, err
 		}
 
-		schema := skydb.FieldType{}
+		schema := skydb.FieldType{
+			UnderlyingType: pqType,
+		}
 		switch pqType {
 		case TypeString:
 			schema.Type = skydb.TypeString
@@ -364,14 +365,10 @@ WHERE a.attrelid = $1 AND a.attnum > 0 AND NOT a.attisdropped`,
 			schema.Type = skydb.TypeInteger
 			integerColumns = append(integerColumns, columnName)
 		default:
-			// We need to enumerate all rows, so do not simply return with the error here
-			columnErrors = append(columnErrors, fmt.Errorf("received unknown data type = %s for column = %s", pqType, columnName))
+			schema.Type = skydb.TypeUnknown
 		}
 
 		typemap[columnName] = schema
-	}
-	if len(columnErrors) > 0 {
-		return nil, columnErrors[0]
 	}
 
 	// STEP 2.1: Convert integer column to sequence column if applicable

--- a/pkg/server/skydb/pq/schema_test.go
+++ b/pkg/server/skydb/pq/schema_test.go
@@ -215,6 +215,17 @@ func TestExtend(t *testing.T) {
 			So(extended, ShouldBeFalse)
 		})
 
+		Convey("cannot creates table with unknown type", func() {
+			So(func() {
+				db.Extend("note", skydb.RecordSchema{
+					"order": skydb.FieldType{
+						Type:           skydb.TypeUnknown,
+						UnderlyingType: "money",
+					},
+				})
+			}, ShouldPanic)
+		})
+
 		Convey("error if creates table with reference not exist", func() {
 			_, err := db.Extend("note", skydb.RecordSchema{
 				"content": skydb.FieldType{Type: skydb.TypeString},
@@ -269,7 +280,7 @@ func TestExtend(t *testing.T) {
 				"dirty":     skydb.FieldType{Type: skydb.TypeNumber},
 			})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "conflicting schema {TypeString  {0 <nil>}} => {TypeNumber  {0 <nil>}}")
+			So(err.Error(), ShouldStartWith, "conflicting schema")
 		})
 
 		Convey("creates empty table", func() {

--- a/pkg/server/skydb/pq/types.go
+++ b/pkg/server/skydb/pq/types.go
@@ -182,3 +182,12 @@ type locationValue skydb.Location
 func (loc locationValue) Value() (driver.Value, error) {
 	return geo.Point(loc).ToWKT(), nil
 }
+
+type nullUnknown struct {
+	Valid bool
+}
+
+func (nu *nullUnknown) Scan(value interface{}) error {
+	nu.Valid = value != nil
+	return nil
+}

--- a/pkg/server/skydb/record_test.go
+++ b/pkg/server/skydb/record_test.go
@@ -173,52 +173,52 @@ func TestRecordACL(t *testing.T) {
 func TestRecordSchema(t *testing.T) {
 	Convey("RecordSchema", t, func() {
 		target := RecordSchema{
-			"content": FieldType{TypeString, "", Expression{}},
-			"date":    FieldType{TypeDateTime, "", Expression{}},
-			"ref":     FieldType{TypeReference, "other", Expression{}},
+			"content": FieldType{Type: TypeString},
+			"date":    FieldType{Type: TypeDateTime},
+			"ref":     FieldType{Type: TypeReference, ReferenceType: "other"},
 		}
 
 		Convey("is superset if equal", func() {
 			other := RecordSchema{
-				"content": FieldType{TypeString, "", Expression{}},
-				"date":    FieldType{TypeDateTime, "", Expression{}},
-				"ref":     FieldType{TypeReference, "other", Expression{}},
+				"content": FieldType{Type: TypeString},
+				"date":    FieldType{Type: TypeDateTime},
+				"ref":     FieldType{Type: TypeReference, ReferenceType: "other"},
 			}
 			So(target.DefinitionSupersetOf(other), ShouldBeTrue)
 		})
 
 		Convey("is superset if target has all columns of the other schema", func() {
 			other := RecordSchema{
-				"content": FieldType{TypeString, "", Expression{}},
-				"date":    FieldType{TypeDateTime, "", Expression{}},
+				"content": FieldType{Type: TypeString},
+				"date":    FieldType{Type: TypeDateTime},
 			}
 			So(target.DefinitionSupersetOf(other), ShouldBeTrue)
 		})
 
 		Convey("is not superset if wrong field type", func() {
 			other := RecordSchema{
-				"content": FieldType{TypeString, "", Expression{}},
-				"date":    FieldType{TypeString, "", Expression{}},
-				"ref":     FieldType{TypeReference, "other", Expression{}},
+				"content": FieldType{Type: TypeString},
+				"date":    FieldType{Type: TypeString},
+				"ref":     FieldType{Type: TypeReference, ReferenceType: "other"},
 			}
 			So(target.DefinitionSupersetOf(other), ShouldBeFalse)
 		})
 
 		Convey("is not superset if wrong reference type", func() {
 			other := RecordSchema{
-				"content": FieldType{TypeString, "", Expression{}},
-				"date":    FieldType{TypeDateTime, "", Expression{}},
-				"ref":     FieldType{TypeReference, "something", Expression{}},
+				"content": FieldType{Type: TypeString},
+				"date":    FieldType{Type: TypeDateTime},
+				"ref":     FieldType{Type: TypeReference, ReferenceType: "something"},
 			}
 			So(target.DefinitionSupersetOf(other), ShouldBeFalse)
 		})
 
 		Convey("is not superset if column not exist in target", func() {
 			other := RecordSchema{
-				"content": FieldType{TypeString, "", Expression{}},
-				"date":    FieldType{TypeDateTime, "", Expression{}},
-				"ref":     FieldType{TypeReference, "other", Expression{}},
-				"tag":     FieldType{TypeString, "", Expression{}},
+				"content": FieldType{Type: TypeString},
+				"date":    FieldType{Type: TypeDateTime},
+				"ref":     FieldType{Type: TypeReference, ReferenceType: "other"},
+				"tag":     FieldType{Type: TypeString},
 			}
 			So(target.DefinitionSupersetOf(other), ShouldBeFalse)
 		})

--- a/pkg/server/skydb/skyconv/map.go
+++ b/pkg/server/skydb/skyconv/map.go
@@ -276,6 +276,22 @@ func (seq MapSequence) ToMap(m map[string]interface{}) {
 	m["$type"] = "seq"
 }
 
+// MapUnknown is skydb.Unknown that can convert to map
+type MapUnknown skydb.Unknown
+
+// FromMap implements FromMapper
+func (val *MapUnknown) FromMap(m map[string]interface{}) error {
+	underlyingType, _ := m["$underlying_type"].(string)
+	*val = MapUnknown{underlyingType}
+	return nil
+}
+
+// ToMap implements ToMapper
+func (val MapUnknown) ToMap(m map[string]interface{}) {
+	m["$type"] = "unknown"
+	m["$underlying_type"] = val.UnderlyingType
+}
+
 type MapACLEntry skydb.RecordACLEntry
 
 // FromMap initializes a RecordACLEntry from a unmarshalled JSON of
@@ -382,6 +398,10 @@ func ParseLiteral(i interface{}) interface{} {
 			return loc
 		case "seq":
 			return skydb.Sequence{}
+		case "unknown":
+			var val skydb.Unknown
+			mapFromOrPanic((*MapUnknown)(&val), value)
+			return val
 		case "relation":
 			var rel MapRelation
 			mapFromOrPanic((*MapRelation)(&rel), value)

--- a/pkg/server/skydb/skyconv/record.go
+++ b/pkg/server/skydb/skyconv/record.go
@@ -42,6 +42,8 @@ func (record *JSONRecord) MarshalJSON() ([]byte, error) {
 			data[key] = (*MapAsset)(v)
 		case skydb.Sequence:
 			data[key] = (MapSequence)(v)
+		case skydb.Unknown:
+			data[key] = (MapUnknown)(v)
 		default:
 			data[key] = value
 		}


### PR DESCRIPTION
This is achieved by introducing a new skydb type called Unknown, which
will be passed to client when the server sees a column with an
unrecognized data type.

Previous behavior will result in skygear server throwing an error when
it sees a column with unrecognized data type.

connects skygeario/skygear-server#231