### PR TITLE
Limit the number of bytes in request log

### DIFF
--- a/main.go
+++ b/main.go
@@ -276,7 +276,7 @@ func main() {
 	}
 
 	if config.LOG.Level == "debug" {
-		finalMux = &router.LoggingMiddleware{
+		loggingMiddleware := &router.LoggingMiddleware{
 			Skips: []string{
 				"/files/",
 				"/_/pubsub/",
@@ -288,6 +288,14 @@ func main() {
 			},
 			Next: finalMux,
 		}
+
+		if config.LOG.RouterByteLimit > 0 {
+			var limit int
+			limit = int(config.LOG.RouterByteLimit)
+			loggingMiddleware.ByteLimit = &limit
+		}
+
+		finalMux = loggingMiddleware
 	}
 
 	// Bootstrap finished, starting services

--- a/pkg/server/skyconfig/config.go
+++ b/pkg/server/skyconfig/config.go
@@ -112,8 +112,9 @@ type Configuration struct {
 		APIKey string `json:"api_key"`
 	} `json:"gcm"`
 	LOG struct {
-		Level        string            `json:"-"`
-		LoggersLevel map[string]string `json:"-"`
+		Level           string            `json:"-"`
+		LoggersLevel    map[string]string `json:"-"`
+		RouterByteLimit int64             `json:"-"`
 	} `json:"log"`
 	LogHook struct {
 		SentryDSN   string
@@ -145,6 +146,7 @@ func NewConfiguration() Configuration {
 	config.LOG.LoggersLevel = map[string]string{
 		"plugin": "info",
 	}
+	config.LOG.RouterByteLimit = 100000
 	config.LogHook.SentryLevel = "error"
 	config.Plugin = map[string]*PluginConfig{}
 	return config
@@ -394,6 +396,10 @@ func (config *Configuration) readLog() {
 		loggerName := strings.ToLower(strings.TrimPrefix(components[0], "LOG_LEVEL_"))
 		loggerLevel := components[1]
 		config.LOG.LoggersLevel[loggerName] = loggerLevel
+	}
+
+	if byteLimit, err := strconv.ParseInt(os.Getenv("LOG_ROUTER_BYTE_LIMIT"), 10, 64); err == nil {
+		config.LOG.RouterByteLimit = byteLimit
 	}
 
 	sentry := os.Getenv("SENTRY_DSN")


### PR DESCRIPTION
The existing implementation prints the response body for certain type
this pose a problem to log collection when the response body is too big.