### PR TITLE
Add _status:healthz endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,6 +195,7 @@ func main() {
 	}
 
 	r.Map("", &handler.HomeHandler{})
+	r.Map("_status:healthz", injector.Inject(&handler.HealthzHandler{}))
 
 	r.Map("auth:signup", injector.Inject(&handler.SignupHandler{}))
 	r.Map("auth:login", injector.Inject(&handler.LoginHandler{}))

--- a/pkg/server/handler/healthz.go
+++ b/pkg/server/handler/healthz.go
@@ -1,0 +1,47 @@
+// Copyright 2015-present Oursky Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"github.com/skygeario/skygear-server/pkg/server/router"
+)
+
+type healthStatusResponse struct {
+	Status string `json:"status,omitempty"`
+}
+
+type HealthzHandler struct {
+	PluginReady   router.Processor `preprocessor:"plugin_ready"`
+	preprocessors []router.Processor
+}
+
+func (h *HealthzHandler) Setup() {
+	h.preprocessors = []router.Processor{
+		h.PluginReady,
+	}
+}
+
+func (h *HealthzHandler) GetPreprocessors() []router.Processor {
+	return h.preprocessors
+}
+
+func (h *HealthzHandler) Handle(playload *router.Payload, response *router.Response) {
+	var (
+		rep healthStatusResponse
+	)
+	rep.Status = "OK"
+	response.Result = rep
+	return
+}

--- a/pkg/server/handler/healthz_test.go
+++ b/pkg/server/handler/healthz_test.go
@@ -1,0 +1,35 @@
+// Copyright 2015-present Oursky Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/skygeario/skygear-server/pkg/server/router"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestHealthzHandler(t *testing.T) {
+	Convey("HealthzHandler", t, func() {
+		req := router.Payload{}
+		resp := router.Response{}
+
+		handler := &HealthzHandler{}
+		handler.Handle(&req, &resp)
+		So(resp.Result, ShouldHaveSameTypeAs, healthStatusResponse{})
+		s := resp.Result.(healthStatusResponse)
+		So(s.Status, ShouldEqual, "OK")
+	})
+}


### PR DESCRIPTION
The healthz endpoint checks if the server is ready to serve request.
This endpoint can be used by cloud deployment or self-hosted
installations to check the status of the server.

connects #264