### PR TITLE
Remove CloseNotifier

### DIFF
--- a/pkg/server/router/logging.go
+++ b/pkg/server/router/logging.go
@@ -68,13 +68,6 @@ func (l *responseLogger) Hijack() (c net.Conn, w *bufio.ReadWriter, e error) {
 	return hijacker.Hijack()
 }
 
-func (l *responseLogger) CloseNotify() <-chan bool {
-	if notifier, ok := l.w.(http.CloseNotifier); ok {
-		return notifier.CloseNotify()
-	}
-	return make(chan bool)
-}
-
 type LoggingMiddleware struct {
 	Skips       []string
 	MimeConcern []string


### PR DESCRIPTION
The CloseNotifier is in conflict with the Hijacker interface (they
cannot be used at the same time). The context will not be cancelled when
the close channel from CloseNotifier is called. This is because the behavior
is not well understood. We can introduce it later if it poses a real problem.

connects #291 