### PR TITLE
Fix schema:fetch when record type has no fields

### DIFF
--- a/pkg/server/handler/schema_test.go
+++ b/pkg/server/handler/schema_test.go
@@ -68,7 +68,9 @@ func TestSchemaResponse(t *testing.T) {
 
 			expected := &schemaResponse{
 				Schemas: map[string]schemaFieldList{
-					"note": schemaFieldList{},
+					"note": schemaFieldList{
+						Fields: []schemaField{},
+					},
 				},
 			}
 			So(result, ShouldResemble, expected)
@@ -651,8 +653,13 @@ func TestSchemaFetchHandler(t *testing.T) {
 			},
 		}
 
+		user := skydb.RecordSchema{}
+
 		db := skydbtest.NewMapDB()
-		_, err := db.Extend("note", note)
+		var err error
+		_, err = db.Extend("note", note)
+		So(err, ShouldBeNil)
+		_, err = db.Extend("user", user)
 		So(err, ShouldBeNil)
 
 		router := handlertest.NewSingleRouteRouter(&SchemaFetchHandler{}, func(p *router.Payload) {
@@ -670,6 +677,9 @@ func TestSchemaFetchHandler(t *testing.T) {
 								{"name": "field1", "type": "string"},
 								{"name": "field2", "type": "datetime"}
 							]
+						},
+						"user": {
+							"fields": []
 						}
 					}
 				}

--- a/pkg/server/handler/schemautil.go
+++ b/pkg/server/handler/schemautil.go
@@ -47,7 +47,11 @@ type schemaField struct {
 func encodeRecordSchemas(data map[string]skydb.RecordSchema) map[string]schemaFieldList {
 	schemaMap := make(map[string]schemaFieldList)
 	for recordType, schema := range data {
-		fieldList := schemaFieldList{}
+		fieldList := schemaFieldList{
+			// initialize array so this will marshal as `[]` instead of
+			// `null`
+			Fields: []schemaField{},
+		}
 		for fieldName, val := range schema {
 			if strings.HasPrefix(fieldName, "_") {
 				continue


### PR DESCRIPTION
The old behavior is that the fields key contains
null value if the record type has no fields. This
is because the slice is not initialized to empty slice.