### PR TITLE
Accept _default_access from API, use when creating record

### DIFF
--- a/pkg/server/handler/recordutil.go
+++ b/pkg/server/handler/recordutil.go
@@ -337,10 +337,19 @@ func mergeRecord(dst, src *skydb.Record) {
 // the same record
 func deriveDeltaRecord(dst, base, delta *skydb.Record) {
 	dst.ID = delta.ID
-	if delta.ACL != nil {
-		dst.ACL = delta.ACL
+	if base.ID.IsEmpty() {
+		// this is a new record
+		if delta.ACL != nil {
+			dst.ACL = delta.ACL
+		} else {
+			dst.ACL = delta.DefaultACL
+		}
 	} else {
-		dst.ACL = base.ACL
+		if delta.ACL != nil {
+			dst.ACL = delta.ACL
+		} else {
+			dst.ACL = base.ACL
+		}
 	}
 	dst.OwnerID = delta.OwnerID
 	dst.CreatedAt = delta.CreatedAt

--- a/pkg/server/skydb/record.go
+++ b/pkg/server/skydb/record.go
@@ -279,6 +279,7 @@ type Record struct {
 	UpdatedAt  time.Time
 	UpdaterID  string
 	ACL        RecordACL
+	DefaultACL RecordACL
 	Data       Data
 	Transient  Data `json:"-"`
 }


### PR DESCRIPTION
connect #309 
depends on https://github.com/SkygearIO/skygear-SDK-JS/pull/175

`_default_access` is used only when `_access` is nil, and server is creating new record