### PR TITLE
Fix inconsistent behavior saving to integer column

### DIFF
--- a/pkg/server/skydb/pq/pq.go
+++ b/pkg/server/skydb/pq/pq.go
@@ -53,6 +53,11 @@ func isUniqueViolated(err error) bool {
 	return false
 }
 
+func isInvalidInputSyntax(err error) bool {
+	pqErr, ok := err.(*pq.Error)
+	return ok && (pqErr.Code == "22P02" || pqErr.Code == "22P03")
+}
+
 func isUndefinedTable(err error) bool {
 	if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "42P01" {
 		return true

--- a/pkg/server/skydb/pq/recorddb.go
+++ b/pkg/server/skydb/pq/recorddb.go
@@ -131,7 +131,13 @@ func (db *database) Save(record *skydb.Record) error {
 
 	row := db.c.QueryRowWith(upsert)
 	if err = newRecordScanner(record.ID.Type, typemap, row).Scan(record); err != nil {
-		return err
+		if isInvalidInputSyntax(err) {
+			return skyerr.NewErrorf(
+				skyerr.InvalidArgument,
+				fmt.Sprintf("failed to save %s: %s", record.ID, err),
+			)
+		}
+		return skyerr.MakeError(err)
 	}
 
 	record.DatabaseID = db.userID

--- a/pkg/server/skydb/pq/schema_test.go
+++ b/pkg/server/skydb/pq/schema_test.go
@@ -280,7 +280,7 @@ func TestExtend(t *testing.T) {
 				"dirty":     skydb.FieldType{Type: skydb.TypeNumber},
 			})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldStartWith, "conflicting schema")
+			So(err.Error(), ShouldStartWith, "IncompatibleSchema: conflicting schema")
 		})
 
 		Convey("creates empty table", func() {
@@ -328,6 +328,24 @@ func TestExtend(t *testing.T) {
 			})
 			So(err, ShouldBeNil)
 			So(extended, ShouldBeFalse)
+		})
+
+		Convey("do not extend if type is different but compatible", func() {
+			extended, err := db.Extend("note", skydb.RecordSchema{
+				"content": skydb.FieldType{Type: skydb.TypeInteger},
+			})
+			So(err, ShouldBeNil)
+			So(extended, ShouldBeTrue)
+
+			for _, canMigrate := range []bool{false, true} {
+				c.canMigrate = canMigrate
+
+				extended, err = db.Extend("note", skydb.RecordSchema{
+					"content": skydb.FieldType{Type: skydb.TypeNumber},
+				})
+				So(err, ShouldBeNil)
+				So(extended, ShouldBeFalse)
+			}
 		})
 	})
 

--- a/pkg/server/skydb/record_test.go
+++ b/pkg/server/skydb/record_test.go
@@ -174,53 +174,65 @@ func TestRecordSchema(t *testing.T) {
 	Convey("RecordSchema", t, func() {
 		target := RecordSchema{
 			"content": FieldType{Type: TypeString},
+			"num":     FieldType{Type: TypeNumber},
 			"date":    FieldType{Type: TypeDateTime},
 			"ref":     FieldType{Type: TypeReference, ReferenceType: "other"},
 		}
 
-		Convey("is superset if equal", func() {
+		Convey("is compatible if equal", func() {
 			other := RecordSchema{
 				"content": FieldType{Type: TypeString},
+				"num":     FieldType{Type: TypeNumber},
 				"date":    FieldType{Type: TypeDateTime},
 				"ref":     FieldType{Type: TypeReference, ReferenceType: "other"},
 			}
-			So(target.DefinitionSupersetOf(other), ShouldBeTrue)
+			So(target.DefinitionCompatibleTo(other), ShouldBeTrue)
 		})
 
-		Convey("is superset if target has all columns of the other schema", func() {
+		Convey("is compatible if target has all columns of the other schema", func() {
 			other := RecordSchema{
 				"content": FieldType{Type: TypeString},
 				"date":    FieldType{Type: TypeDateTime},
 			}
-			So(target.DefinitionSupersetOf(other), ShouldBeTrue)
+			So(target.DefinitionCompatibleTo(other), ShouldBeTrue)
 		})
 
-		Convey("is not superset if wrong field type", func() {
+		Convey("is compatible if different type but compatible type", func() {
+			other := RecordSchema{
+				"content": FieldType{Type: TypeString},
+				"num":     FieldType{Type: TypeInteger},
+				"date":    FieldType{Type: TypeString},
+				"ref":     FieldType{Type: TypeReference, ReferenceType: "other"},
+			}
+			So(target.DefinitionCompatibleTo(other), ShouldBeFalse)
+		})
+
+		Convey("is not compatible if wrong field type", func() {
 			other := RecordSchema{
 				"content": FieldType{Type: TypeString},
 				"date":    FieldType{Type: TypeString},
 				"ref":     FieldType{Type: TypeReference, ReferenceType: "other"},
 			}
-			So(target.DefinitionSupersetOf(other), ShouldBeFalse)
+			So(target.DefinitionCompatibleTo(other), ShouldBeFalse)
 		})
 
-		Convey("is not superset if wrong reference type", func() {
+		Convey("is not compatible if wrong reference type", func() {
 			other := RecordSchema{
 				"content": FieldType{Type: TypeString},
 				"date":    FieldType{Type: TypeDateTime},
 				"ref":     FieldType{Type: TypeReference, ReferenceType: "something"},
 			}
-			So(target.DefinitionSupersetOf(other), ShouldBeFalse)
+			So(target.DefinitionCompatibleTo(other), ShouldBeFalse)
 		})
 
-		Convey("is not superset if column not exist in target", func() {
+		Convey("is not compatible if column not exist in target", func() {
 			other := RecordSchema{
 				"content": FieldType{Type: TypeString},
 				"date":    FieldType{Type: TypeDateTime},
 				"ref":     FieldType{Type: TypeReference, ReferenceType: "other"},
 				"tag":     FieldType{Type: TypeString},
 			}
-			So(target.DefinitionSupersetOf(other), ShouldBeFalse)
+			So(target.DefinitionCompatibleTo(other), ShouldBeFalse)
 		})
 	})
 }


### PR DESCRIPTION
When saving to integer column, the request my fail depending on different
dev mode settings. This is due to separate checking involved when
determining if two record schemas are compatible.

connects #319