### PR TITLE
Fix zmq issue with chat plugin

### DIFF
--- a/pkg/server/plugin/exec/process.go
+++ b/pkg/server/plugin/exec/process.go
@@ -198,7 +198,7 @@ func (p *execTransport) RunHandler(ctx context.Context, name string, in []byte) 
 	return
 }
 
-func (p *execTransport) RunHook(ctx context.Context, hookName string, record *skydb.Record, originalRecord *skydb.Record) (*skydb.Record, error) {
+func (p *execTransport) RunHook(ctx context.Context, hookName string, record *skydb.Record, originalRecord *skydb.Record, async bool) (*skydb.Record, error) {
 	param := map[string]interface{}{
 		"record":   (*skyconv.JSONRecord)(record),
 		"original": (*skyconv.JSONRecord)(originalRecord),

--- a/pkg/server/plugin/exec/process_test.go
+++ b/pkg/server/plugin/exec/process_test.go
@@ -338,7 +338,7 @@ func TestRun(t *testing.T) {
 				}`), nil
 			}
 
-			recordout, err := transport.RunHook(nil, "note_beforeSave", &recordin, &recordold)
+			recordout, err := transport.RunHook(nil, "note_beforeSave", &recordin, &recordold, false)
 			So(err, ShouldBeNil)
 			So(called, ShouldBeTrue)
 
@@ -468,7 +468,7 @@ func TestRun(t *testing.T) {
 				}`), nil
 			}
 
-			recordout, err := transport.RunHook(nil, "note_beforeSave", &recordin, nil)
+			recordout, err := transport.RunHook(nil, "note_beforeSave", &recordin, nil, false)
 			So(err, ShouldBeNil)
 			So(called, ShouldBeTrue)
 
@@ -557,7 +557,7 @@ func TestRun(t *testing.T) {
 				}`), nil
 			}
 
-			recordout, err := transport.RunHook(nil, "note_beforeSave", &recordin, nil)
+			recordout, err := transport.RunHook(nil, "note_beforeSave", &recordin, nil, false)
 			So(err, ShouldBeNil)
 			So(called, ShouldBeTrue)
 			So(*recordout, ShouldResemble, recordin)
@@ -593,7 +593,7 @@ func TestRun(t *testing.T) {
 				}`), nil
 			}
 
-			recordout, err := transport.RunHook(nil, "note_beforeSave", &recordin, nil)
+			recordout, err := transport.RunHook(nil, "note_beforeSave", &recordin, nil, false)
 			So(err, ShouldBeNil)
 			So(called, ShouldBeTrue)
 			So(*recordout, ShouldResemble, recordin)
@@ -604,7 +604,7 @@ func TestRun(t *testing.T) {
 				return nil, errors.New("worrying error")
 			}
 
-			recordout, err := transport.RunHook(nil, "note_afterSave", &recordin, nil)
+			recordout, err := transport.RunHook(nil, "note_afterSave", &recordin, nil, false)
 			So(err.Error(), ShouldEqual, "worrying error")
 			So(recordout, ShouldBeNil)
 		})
@@ -614,7 +614,7 @@ func TestRun(t *testing.T) {
 				return []byte("I am not a json"), nil
 			}
 
-			recordout, err := transport.RunHook(nil, "note_afterSave", &recordin, nil)
+			recordout, err := transport.RunHook(nil, "note_afterSave", &recordin, nil, false)
 			So(err.Error(), ShouldEqual, "failed to parse plugin response: invalid character 'I' looking for beginning of value")
 			So(recordout, ShouldBeNil)
 		})
@@ -633,7 +633,7 @@ func TestRun(t *testing.T) {
 				}`), nil
 			}
 
-			recordout, err := transport.RunHook(nil, "note_afterSave", &recordin, nil)
+			recordout, err := transport.RunHook(nil, "note_afterSave", &recordin, nil, false)
 			sError, ok := err.(skyerr.Error)
 			So(ok, ShouldBeTrue)
 			So(sError.Message(), ShouldEqual, `Too strong to lift a feather`)
@@ -655,7 +655,7 @@ func TestRun(t *testing.T) {
 
 			ctx := context.WithValue(context.Background(), router.UserIDContextKey, "user")
 			ctx = context.WithValue(ctx, router.AccessKeyTypeContextKey, router.MasterAccessKey)
-			transport.RunHook(ctx, "note_afterSave", &recordin, nil)
+			transport.RunHook(ctx, "note_afterSave", &recordin, nil, false)
 			So(executed, ShouldBeTrue)
 		})
 	})

--- a/pkg/server/plugin/hook.go
+++ b/pkg/server/plugin/hook.go
@@ -26,7 +26,7 @@ import (
 // plugin
 func CreateHookFunc(p *Plugin, hookInfo pluginHookInfo) hook.Func {
 	hookFunc := func(ctx context.Context, record *skydb.Record, oldRecord *skydb.Record) skyerr.Error {
-		recordout, err := p.transport.RunHook(ctx, hookInfo.Name, record, oldRecord)
+		recordout, err := p.transport.RunHook(ctx, hookInfo.Name, record, oldRecord, hookInfo.Async)
 		if err == nil && hookInfo.Trigger == string(hook.BeforeSave) && !hookInfo.Async {
 			*record = *recordout
 		}

--- a/pkg/server/plugin/hook_test.go
+++ b/pkg/server/plugin/hook_test.go
@@ -29,7 +29,7 @@ type hookOnlyTransport struct {
 	Transport
 }
 
-func (t *hookOnlyTransport) RunHook(ctx context.Context, hookName string, record *skydb.Record, originalRecord *skydb.Record) (*skydb.Record, error) {
+func (t *hookOnlyTransport) RunHook(ctx context.Context, hookName string, record *skydb.Record, originalRecord *skydb.Record, async bool) (*skydb.Record, error) {
 	return t.RunHookFunc(ctx, hookName, record, originalRecord)
 }
 

--- a/pkg/server/plugin/http/http.go
+++ b/pkg/server/plugin/http/http.go
@@ -131,8 +131,8 @@ func (p *httpTransport) RunHandler(ctx context.Context, name string, in []byte) 
 	return
 }
 
-func (p *httpTransport) RunHook(ctx context.Context, hookName string, record *skydb.Record, originalRecord *skydb.Record) (*skydb.Record, error) {
-	out, err := p.rpc(pluginrequest.NewHookRequest(ctx, hookName, record, originalRecord))
+func (p *httpTransport) RunHook(ctx context.Context, hookName string, record *skydb.Record, originalRecord *skydb.Record, async bool) (*skydb.Record, error) {
+	out, err := p.rpc(pluginrequest.NewHookRequest(ctx, hookName, record, originalRecord, async))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/plugin/http/http_test.go
+++ b/pkg/server/plugin/http/http_test.go
@@ -264,7 +264,7 @@ func TestRun(t *testing.T) {
 				},
 			)
 
-			recordout, err := transport.RunHook(ctx, "beforeSave", &recordin, &recordold)
+			recordout, err := transport.RunHook(ctx, "beforeSave", &recordin, &recordold, false)
 			So(err, ShouldBeNil)
 
 			datein := recordin.Data["date"].(time.Time)

--- a/pkg/server/plugin/request/request.go
+++ b/pkg/server/plugin/request/request.go
@@ -29,6 +29,7 @@ type Request struct {
 	Kind    string
 	Name    string
 	Param   interface{}
+	Async   bool
 }
 
 // HookRequest contains records involved in a database hook.
@@ -53,12 +54,12 @@ func NewHandlerRequest(ctx context.Context, name string, input json.RawMessage) 
 }
 
 // NewHookRequest creates a new hook request.
-func NewHookRequest(ctx context.Context, hookName string, record *skydb.Record, originalRecord *skydb.Record) *Request {
+func NewHookRequest(ctx context.Context, hookName string, record *skydb.Record, originalRecord *skydb.Record, async bool) *Request {
 	param := HookRequest{
 		Record:   (*skyconv.JSONRecord)(record),
 		Original: (*skyconv.JSONRecord)(originalRecord),
 	}
-	return &Request{Kind: "hook", Name: hookName, Param: param, Context: ctx}
+	return &Request{Kind: "hook", Name: hookName, Param: param, Context: ctx, Async: async}
 }
 
 // NewAuthRequest creates a new auth request.

--- a/pkg/server/plugin/transport.go
+++ b/pkg/server/plugin/transport.go
@@ -82,7 +82,7 @@ type Transport interface {
 	// A skydb.Record is returned as a result of invocation. Such record must be
 	// a newly allocated instance, and may not share any reference type values
 	// in any of its memebers with the record being passed in.
-	RunHook(ctx context.Context, hookName string, record *skydb.Record, oldRecord *skydb.Record) (*skydb.Record, error)
+	RunHook(ctx context.Context, hookName string, record *skydb.Record, oldRecord *skydb.Record, async bool) (*skydb.Record, error)
 
 	RunTimer(name string, in []byte) ([]byte, error)
 

--- a/pkg/server/plugin/transport_test.go
+++ b/pkg/server/plugin/transport_test.go
@@ -50,7 +50,7 @@ func (t *nullTransport) RunHandler(ctx context.Context, name string, in []byte) 
 	out = in
 	return
 }
-func (t *nullTransport) RunHook(ctx context.Context, hookName string, reocrd *skydb.Record, oldRecord *skydb.Record) (record *skydb.Record, err error) {
+func (t *nullTransport) RunHook(ctx context.Context, hookName string, reocrd *skydb.Record, oldRecord *skydb.Record, async bool) (record *skydb.Record, err error) {
 	t.lastContext = ctx
 	return
 }


### PR DESCRIPTION
connect https://github.com/SkygearIO/skygear-server/issues/342

This PR makes sure when server is calling an async hook, it does not reuse worker.

After fixing the bug, chat still does not work because of another bug: Heartbeat will put workers back to the pool, which is not preferred because it may be waiting for a response of a nested request. This is fixed too.