### PR TITLE
Fix potential problem when saving new record

### DIFF
--- a/.gogocyclo
+++ b/.gogocyclo
@@ -7,3 +7,4 @@ ignores = `skyconv`.ParseLiteral
 ignores = `zmq`.(*Broker).Run
 ignores = `skyconv`.(*JSONRecord).MarshalJSON
 ignores = `skydb`.DeriveFieldType
+ignores = `handler`.recordSaveHandler

--- a/pkg/server/handler/record_test.go
+++ b/pkg/server/handler/record_test.go
@@ -548,6 +548,8 @@ type bogusFieldDatabase struct {
 
 func (db bogusFieldDatabase) IsReadOnly() bool { return false }
 
+func (db bogusFieldDatabase) ID() string { return "" }
+
 func (db bogusFieldDatabase) Extend(recordType string, schema skydb.RecordSchema) (bool, error) {
 	return false, nil
 }
@@ -624,10 +626,8 @@ func TestRecordSaveBogusField(t *testing.T) {
 		Convey("can save without specifying seq", func(c C) {
 			db.SaveFunc = func(record *skydb.Record) error {
 				c.So(record, ShouldResemble, &skydb.Record{
-					ID: skydb.NewRecordID("record", "id"),
-					Data: skydb.Data{
-						"seq": int64(1),
-					},
+					ID:        skydb.NewRecordID("record", "id"),
+					Data:      skydb.Data{},
 					OwnerID:   "user0",
 					CreatorID: "user0",
 					UpdaterID: "user0",
@@ -637,6 +637,12 @@ func TestRecordSaveBogusField(t *testing.T) {
 			}
 			db.GetFunc = func(id skydb.RecordID, record *skydb.Record) error {
 				c.So(id, ShouldResemble, skydb.NewRecordID("record", "id"))
+				record.ID = skydb.NewRecordID("record", "id")
+				record.OwnerID = "user0"
+				record.CreatorID = "user0"
+				record.CreatedAt = timeNow()
+				record.UpdaterID = "user0"
+				record.UpdatedAt = timeNow()
 				record.Data = skydb.Data{
 					"seq": int64(1),
 				}

--- a/pkg/server/skydb/record.go
+++ b/pkg/server/skydb/record.go
@@ -273,6 +273,32 @@ func (r *Record) Accessible(userinfo *UserInfo, level RecordACLLevel) bool {
 	return r.ACL.Accessible(userinfo, level)
 }
 
+// Copy copies the content of the record.
+func (r *Record) Copy() *Record {
+	var dst Record
+	dst = *r
+
+	// creating a new map is essential because map is a reference type
+	dst.Data = map[string]interface{}{}
+	for key, value := range r.Data {
+		dst.Data[key] = value
+	}
+	return &dst
+}
+
+// Apply modifies the content of the record with the specified record.
+func (r *Record) Apply(src *Record) {
+	r.ACL = src.ACL
+
+	if r.Data == nil {
+		r.Data = map[string]interface{}{}
+	}
+
+	for key, value := range src.Data {
+		r.Data[key] = value
+	}
+}
+
 // RecordSchema is a mapping of record key to its value's data type or reference
 type RecordSchema map[string]FieldType
 

--- a/pkg/server/skydb/skydbtest/skydbtest.go
+++ b/pkg/server/skydb/skydbtest/skydbtest.go
@@ -321,7 +321,7 @@ func (db *MapDB) DatabaseType() skydb.DatabaseType { return skydb.PublicDatabase
 
 // ID returns a mock Database ID.
 func (db *MapDB) ID() string {
-	return "map-db"
+	return ""
 }
 
 func (db *MapDB) UserRecordType() string {


### PR DESCRIPTION
recordSaveHandler (recordutil.go) did not check if the fetched
record is a new record or an existing record, causing the
originalRecordMap to contain incorrect data. This PR also removes
the need for a hot fix to populate new record fields.