### PR TITLE
Fix handler/query does not allow joined query

### DIFF
--- a/pkg/server/handler/query.go
+++ b/pkg/server/handler/query.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -146,10 +145,6 @@ func (parser *QueryParser) predicateFromRaw(rawPredicate []interface{}) skydb.Pr
 	} else {
 		for i := 1; i < len(rawPredicate); i++ {
 			expr := parser.parseExpression(rawPredicate[i])
-			if expr.Type == skydb.KeyPath && strings.Contains(expr.Value.(string), ".") {
-
-				panic(fmt.Errorf("key path `%s` is not supported", expr.Value))
-			}
 			predicate.Children = append(predicate.Children, expr)
 		}
 	}

--- a/pkg/server/handler/query_test.go
+++ b/pkg/server/handler/query_test.go
@@ -22,11 +22,41 @@ import (
 )
 
 func TestQueryFromRaw(t *testing.T) {
-	Convey("functional predicate", t, func() {
+	Convey("QueryParser", t, func() {
+		parser := &QueryParser{
+			UserID: "USER_ID",
+		}
+
+		Convey("should parse simple predicate with multi-components keypath", func() {
+			query := skydb.Query{}
+			err := parser.queryFromRaw(map[string]interface{}{
+				"record_type": "note",
+				"predicate": []interface{}{
+					"eq",
+					map[string]interface{}{"$type": "keypath", "$val": "category.name"},
+					"Interesting",
+				},
+			}, &query)
+			So(err, ShouldBeNil)
+			So(query, ShouldResemble, skydb.Query{
+				Type: "note",
+				Predicate: skydb.Predicate{
+					skydb.Equal,
+					[]interface{}{
+						skydb.Expression{
+							Type:  skydb.KeyPath,
+							Value: "category.name",
+						},
+						skydb.Expression{
+							Type:  skydb.Literal,
+							Value: "Interesting",
+						},
+					},
+				},
+			})
+		})
+
 		Convey("functional predicate with user relation", func() {
-			parser := &QueryParser{
-				UserID: "USER_ID",
-			}
 			query := skydb.Query{}
 			err := parser.queryFromRaw(map[string]interface{}{
 				"record_type": "note",
@@ -53,9 +83,6 @@ func TestQueryFromRaw(t *testing.T) {
 		})
 
 		Convey("functional predicate with user friend relation", func() {
-			parser := &QueryParser{
-				UserID: "USER_ID",
-			}
 			query := skydb.Query{}
 			err := parser.queryFromRaw(map[string]interface{}{
 				"record_type": "note",
@@ -82,9 +109,6 @@ func TestQueryFromRaw(t *testing.T) {
 		})
 
 		Convey("functional predicate with user discover", func() {
-			parser := &QueryParser{
-				UserID: "USER_ID",
-			}
 			query := skydb.Query{}
 			err := parser.queryFromRaw(map[string]interface{}{
 				"record_type": "note",

--- a/pkg/server/skydb/pq/builder/factory.go
+++ b/pkg/server/skydb/pq/builder/factory.go
@@ -196,6 +196,7 @@ func (f *predicateSqlizerFactory) newUserDiscoverFunctionalPredicateSqlizer(fn s
 
 func (f *predicateSqlizerFactory) NewAccessControlSqlizer(user *skydb.UserInfo, aclLevel skydb.RecordACLLevel) (sq.Sqlizer, error) {
 	return &accessPredicateSqlizer{
+		f.primaryTable,
 		user,
 		aclLevel,
 	}, nil

--- a/pkg/server/skydb/pq/builder/predicate_test.go
+++ b/pkg/server/skydb/pq/builder/predicate_test.go
@@ -302,42 +302,45 @@ func TestAccessPredicateSqlizer(t *testing.T) {
 				ID: "userid",
 			}
 			sqlizer := &accessPredicateSqlizer{
+				"note",
 				&userinfo,
 				skydb.ReadLevel,
 			}
 			sql, args, err := sqlizer.ToSql()
 			So(err, ShouldBeNil)
 			So(sql, ShouldEqual,
-				`(_access @> '[{"user_id": "userid"}]' OR `+
-					`_owner_id = ? OR `+
-					`_access @> '[{"public": true}]' OR `+
-					`_access IS NULL)`)
+				`("note"."_access" @> '[{"user_id": "userid"}]' OR `+
+					`"note"."_owner_id" = ? OR `+
+					`"note"."_access" @> '[{"public": true}]' OR `+
+					`"note"."_access" IS NULL)`)
 			So(args, ShouldResemble, []interface{}{"userid"})
 		})
 
 		Convey("serialized for nil user and read", func() {
 			sqlizer := &accessPredicateSqlizer{
+				"",
 				nil,
 				skydb.ReadLevel,
 			}
 			sql, args, err := sqlizer.ToSql()
 			So(err, ShouldBeNil)
 			So(sql, ShouldEqual,
-				`(_access @> '[{"public": true}]' OR `+
-					`_access IS NULL)`)
+				`("_access" @> '[{"public": true}]' OR `+
+					`"_access" IS NULL)`)
 			So(args, ShouldResemble, []interface{}{})
 		})
 
 		Convey("serialized for nil user and write", func() {
 			sqlizer := &accessPredicateSqlizer{
+				"",
 				nil,
 				skydb.WriteLevel,
 			}
 			sql, args, err := sqlizer.ToSql()
 			So(err, ShouldBeNil)
 			So(sql, ShouldEqual,
-				`(_access @> '[{"public": true, "level": "write"}]' OR `+
-					`_access IS NULL)`)
+				`("_access" @> '[{"public": true, "level": "write"}]' OR `+
+					`"_access" IS NULL)`)
 			So(args, ShouldResemble, []interface{}{})
 		})
 
@@ -347,18 +350,19 @@ func TestAccessPredicateSqlizer(t *testing.T) {
 				Roles: []string{"admin", "writer"},
 			}
 			sqlizer := &accessPredicateSqlizer{
+				"",
 				&userinfo,
 				skydb.ReadLevel,
 			}
 			sql, args, err := sqlizer.ToSql()
 			So(err, ShouldBeNil)
 			So(sql, ShouldEqual,
-				`(_access @> '[{"role": "admin"}]' OR `+
-					`_access @> '[{"role": "writer"}]' OR `+
-					`_access @> '[{"user_id": "userid"}]' OR `+
-					`_owner_id = ? OR `+
-					`_access @> '[{"public": true}]' OR `+
-					`_access IS NULL)`)
+				`("_access" @> '[{"role": "admin"}]' OR `+
+					`"_access" @> '[{"role": "writer"}]' OR `+
+					`"_access" @> '[{"user_id": "userid"}]' OR `+
+					`"_owner_id" = ? OR `+
+					`"_access" @> '[{"public": true}]' OR `+
+					`"_access" IS NULL)`)
 			So(args, ShouldResemble, []interface{}{"userid"})
 		})
 	})


### PR DESCRIPTION
This is caused by two problems: The query parser did not accept keypaths
with multiple components and the `_access` identifier in SQL is not
fully qualified.