### PR TITLE
Move delete old generated mock files after go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,7 @@ vendor:
 .PHONY: generate
 generate:
 # go install is required before go generate.
-	find pkg -type f -name "mock_*.go" -delete
-	$(DOCKER_RUN) sh -c 'go install $(GO_BUILD_ARGS) && go generate ./pkg/...'
+	$(DOCKER_RUN) sh -c 'go install $(GO_BUILD_ARGS) && find pkg -type f -name "mock_*.go" -delete && go generate ./pkg/...'
 .PHONY: build
 build:
 	$(DOCKER_RUN) go build -o $(DIST) $(GO_BUILD_ARGS)


### PR DESCRIPTION
This makes less pain to developer if the source can not build properly and the generated files would not be gone.