### PR TITLE
Use NewGoroutineAwareTestReporter handler tests

### DIFF
--- a/pkg/server/handler/role_test.go
+++ b/pkg/server/handler/role_test.go
@@ -181,7 +181,7 @@ func TestRoleAdminHandler(t *testing.T) {
 
 func TestRoleAssignHandler(t *testing.T) {
 	Convey("RoleAssignHandler", t, func() {
-		ctrl := gomock.NewController(t)
+		ctrl := gomock.NewController(handlertest.NewGoroutineAwareTestReporter(t))
 		defer ctrl.Finish()
 
 		conn := mock_skydb.NewMockConn(ctrl)
@@ -274,7 +274,7 @@ func TestRoleAssignHandler(t *testing.T) {
 
 func TestRoleRevokeHandler(t *testing.T) {
 	Convey("RoleRevokeHandler", t, func() {
-		ctrl := gomock.NewController(t)
+		ctrl := gomock.NewController(handlertest.NewGoroutineAwareTestReporter(t))
 		defer ctrl.Finish()
 
 		conn := mock_skydb.NewMockConn(ctrl)


### PR DESCRIPTION
This is required because the handler is executed in a different goroutine,
which the mock controller will call testing.T. testing.T should
only be called from the same goroutine.