### PR TITLE
New user profile design: auth request with auth data and response with user record

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func main() {
 		ClientKey:     config.App.APIKey,
 		MasterKey:     config.App.MasterKey,
 	}
-	preprocessorRegistry["inject_user"] = &pp.InjectUserIfPresent{}
+	preprocessorRegistry["inject_auth"] = &pp.InjectAuthIfPresent{}
 	preprocessorRegistry["require_user"] = &pp.RequireUser{}
 	preprocessorRegistry["inject_db"] = &pp.InjectDatabase{}
 	preprocessorRegistry["inject_public_db"] = &pp.InjectPublicDatabase{}

--- a/main.go
+++ b/main.go
@@ -142,6 +142,7 @@ func main() {
 		MasterKey:     config.App.MasterKey,
 	}
 	preprocessorRegistry["inject_auth"] = &pp.InjectAuthIfPresent{}
+	preprocessorRegistry["inject_user"] = &pp.InjectUserIfPresent{}
 	preprocessorRegistry["require_user"] = &pp.RequireUser{}
 	preprocessorRegistry["inject_db"] = &pp.InjectDatabase{}
 	preprocessorRegistry["inject_public_db"] = &pp.InjectPublicDatabase{}

--- a/pkg/server/authtoken/jwt.go
+++ b/pkg/server/authtoken/jwt.go
@@ -90,7 +90,7 @@ func (r *JWTStore) Get(accessToken string, token *Token) error {
 	// The token is considered valid by the JWTStore. (i.e. the token
 	// has a valid signature and the signature is verified with the secret.)
 	//
-	// In skygear-server, the `InjectUserIfPresent` preprocessor is
+	// In skygear-server, the `InjectAuthIfPresent` preprocessor is
 	// responsible for checking if the token is still valid. A token
 	// might become invalid if the user has changed the password after the
 	// token is generated.

--- a/pkg/server/handler/auth.go
+++ b/pkg/server/handler/auth.go
@@ -471,7 +471,7 @@ type PasswordHandler struct {
 	TokenStore    authtoken.Store  `inject:"TokenStore"`
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
@@ -481,7 +481,7 @@ func (h *PasswordHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.PluginReady,
 	}
@@ -526,7 +526,7 @@ func (h *PasswordHandler) Handle(payload *router.Payload, response *router.Respo
 		log.Warningf("Invalidate is not yet implement")
 		// TODO: invalidate all existing token and generate a new one for response
 	}
-	// Generate new access-token. Because InjectUserIfPresent preprocessor
+	// Generate new access-token. Because InjectAuthIfPresent preprocessor
 	// will expire existing access-token.
 	store := h.TokenStore
 	token, err := store.NewToken(payload.AppName, info.ID)

--- a/pkg/server/handler/auth.go
+++ b/pkg/server/handler/auth.go
@@ -189,7 +189,10 @@ func (h *SignupHandler) Handle(payload *router.Payload, response *router.Respons
 		panic(err)
 	}
 
-	authResponse, err := AuthResponseFactory{}.NewAuthResponse(payload.DBConn, info, *user, token.AccessToken)
+	authResponse, err := AuthResponseFactory{
+		AssetStore: h.AssetStore,
+		Conn:       payload.DBConn,
+	}.NewAuthResponse(info, *user, token.AccessToken)
 	if err != nil {
 		response.Err = skyerr.MakeError(err)
 		return
@@ -301,7 +304,10 @@ func (h *LoginHandler) Handle(payload *router.Payload, response *router.Response
 		panic(err)
 	}
 
-	authResponse, err := AuthResponseFactory{}.NewAuthResponse(payload.DBConn, info, user, token.AccessToken)
+	authResponse, err := AuthResponseFactory{
+		AssetStore: h.AssetStore,
+		Conn:       payload.DBConn,
+	}.NewAuthResponse(info, user, token.AccessToken)
 	if err != nil {
 		response.Err = skyerr.MakeError(err)
 		return

--- a/pkg/server/handler/auth.go
+++ b/pkg/server/handler/auth.go
@@ -31,8 +31,7 @@ import (
 var errUserDuplicated = skyerr.NewError(skyerr.Duplicated, "user duplicated")
 
 type signupPayload struct {
-	Username         string                 `mapstructure:"username"`
-	Email            string                 `mapstructure:"email"`
+	AuthData         skydb.AuthData         `mapstructure:"auth_data"`
 	Password         string                 `mapstructure:"password"`
 	Provider         string                 `mapstructure:"provider"`
 	ProviderAuthData map[string]interface{} `mapstructure:"provider_auth_data"`
@@ -46,13 +45,12 @@ func (payload *signupPayload) Decode(data map[string]interface{}) skyerr.Error {
 }
 
 func (payload *signupPayload) Validate() skyerr.Error {
-
 	if payload.IsAnonymous() {
 		//no validation logic for anonymous sign up
 	} else if payload.Provider == "" {
-		identified := payload.Username != "" || payload.Email != ""
+		identified := payload.AuthData.IsValid()
 		if !identified {
-			return skyerr.NewInvalidArgument("empty username and empty email", []string{"username", "email"})
+			return skyerr.NewInvalidArgument("invalid auth data", []string{"auth_data"})
 		}
 
 		if payload.Password == "" {
@@ -64,28 +62,32 @@ func (payload *signupPayload) Validate() skyerr.Error {
 }
 
 func (payload *signupPayload) IsAnonymous() bool {
-	return payload.Email == "" && payload.Password == "" && payload.Username == "" && payload.Provider == ""
+	return payload.AuthData.IsEmpty() && payload.Password == "" && payload.Provider == ""
 }
 
 // SignupHandler creates an AuthInfo with the supplied information.
 //
 // SignupHandler receives three parameters:
 //
-// * username (string, unique, optional)
-// * email  (string, unqiue, optional)
+// * auth_data (json object, optional)
 // * password (string, optional)
 //
-// If both username and email is not supplied, an anonymous user is created and
+// If auth_data is not supplied, an anonymous user is created and
 // have user_id auto-generated. SignupHandler writes an error to
 // response.Result if the supplied username or email collides with an existing
 // username.
+//
+// Any entry with null value in auth_data would be purged. If all entries are
+// having null value, this would be treated as anonymous sign up.
 //
 //  curl -X POST -H "Content-Type: application/json" \
 //    -d @- http://localhost:3000/ <<EOF
 //  {
 //      "action": "auth:signup",
-//      "username": "rickmak",
-//      "email": "rick.mak@gmail.com",
+//      "auth_data": {
+//        "username": "rickmak",
+//        "email": "rick.mak@gmail.com",
+//      },
 //      "password": "123456"
 //  }
 //  EOF
@@ -149,9 +151,7 @@ func (h *SignupHandler) Handle(payload *router.Payload, response *router.Respons
 		info = skydb.NewProviderInfoAuthInfo(principalID, providerAuthData)
 	} else {
 		info = skydb.NewAuthInfo(p.Password)
-		authdata = skydb.AuthData{}
-		authdata.SetUsername(p.Username)
-		authdata.SetEmail(p.Email)
+		authdata = p.AuthData
 	}
 
 	// Populate the default roles to user
@@ -173,12 +173,9 @@ func (h *SignupHandler) Handle(payload *router.Payload, response *router.Respons
 		payload.DBConn, payload.Database, h.AssetStore, h.HookRegistry, payload.Context,
 	}
 
-	if ok := authdata.IsValid(); !ok {
-		response.Err = skyerr.NewInvalidArgument("Unexpected key found", []string{"authdata"})
-		return
-	}
-
-	if response.Err = createContext.execute(&info, authdata); response.Err != nil {
+	user, skyErr := createContext.execute(&info, authdata)
+	if skyErr != nil {
+		response.Err = skyErr
 		return
 	}
 
@@ -192,12 +189,17 @@ func (h *SignupHandler) Handle(payload *router.Payload, response *router.Respons
 		panic(err)
 	}
 
-	response.Result = NewAuthResponse(info, authdata, token.AccessToken)
+	authResponse, err := AuthResponseFactory{}.NewAuthResponse(payload.DBConn, info, *user, token.AccessToken)
+	if err != nil {
+		response.Err = skyerr.MakeError(err)
+		return
+	}
+
+	response.Result = authResponse
 }
 
 type loginPayload struct {
-	Username         string                 `mapstructure:"username"`
-	Email            string                 `mapstructure:"email"`
+	AuthData         skydb.AuthData         `mapstructure:"auth_data"`
 	Password         string                 `mapstructure:"password"`
 	Provider         string                 `mapstructure:"provider"`
 	ProviderAuthData map[string]interface{} `mapstructure:"provider_auth_data"`
@@ -211,6 +213,13 @@ func (payload *loginPayload) Decode(data map[string]interface{}) skyerr.Error {
 }
 
 func (payload *loginPayload) Validate() skyerr.Error {
+	if payload.Provider == "" {
+		identified := payload.AuthData.IsValid()
+		if !identified {
+			return skyerr.NewInvalidArgument("invalid auth data", []string{"auth_data"})
+		}
+	}
+
 	return nil
 }
 
@@ -268,16 +277,16 @@ func (h *LoginHandler) Handle(payload *router.Payload, response *router.Response
 	store := h.TokenStore
 
 	info := skydb.AuthInfo{}
-	authdata := skydb.AuthData{}
+	user := skydb.Record{}
 
-	var handleLoginFunc func(*router.Payload, *loginPayload, *skydb.AuthInfo, *skydb.AuthData) skyerr.Error
+	var handleLoginFunc func(*router.Payload, *loginPayload, *skydb.AuthInfo, *skydb.Record) skyerr.Error
 	if p.Provider != "" {
 		handleLoginFunc = h.handleLoginWithProvider
 	} else {
 		handleLoginFunc = h.handleLoginWithAuthData
 	}
 
-	if skyErr = handleLoginFunc(payload, p, &info, &authdata); skyErr != nil {
+	if skyErr = handleLoginFunc(payload, p, &info, &user); skyErr != nil {
 		response.Err = skyErr
 		return
 	}
@@ -292,7 +301,12 @@ func (h *LoginHandler) Handle(payload *router.Payload, response *router.Response
 		panic(err)
 	}
 
-	authResponse := NewAuthResponse(info, authdata, token.AccessToken)
+	authResponse, err := AuthResponseFactory{}.NewAuthResponse(payload.DBConn, info, user, token.AccessToken)
+	if err != nil {
+		response.Err = skyerr.MakeError(err)
+		return
+	}
+
 	// Populate the activity time to user
 	now := timeNow()
 	info.LastLoginAt = &now
@@ -304,8 +318,7 @@ func (h *LoginHandler) Handle(payload *router.Payload, response *router.Response
 	response.Result = authResponse
 }
 
-func (h *LoginHandler) handleLoginWithProvider(payload *router.Payload, p *loginPayload, authinfo *skydb.AuthInfo, authdata *skydb.AuthData) skyerr.Error {
-	*authdata = skydb.AuthData{}
+func (h *LoginHandler) handleLoginWithProvider(payload *router.Payload, p *loginPayload, authinfo *skydb.AuthInfo, user *skydb.Record) skyerr.Error {
 	principalID, providerAuthData, skyErr := h.authPrincipal(payload.Context, p)
 	if skyErr != nil {
 		return skyErr
@@ -315,7 +328,7 @@ func (h *LoginHandler) handleLoginWithProvider(payload *router.Payload, p *login
 		// Create user if and only if no user found with the same principal
 		if err != skydb.ErrUserNotFound {
 			// TODO: more error handling here if necessary
-			return skyerr.NewResourceFetchFailureErr("user", p.Username)
+			return skyerr.NewResourceFetchFailureErr("auth_data", p.AuthData)
 		}
 
 		*authinfo = skydb.NewProviderInfoAuthInfo(principalID, providerAuthData)
@@ -324,12 +337,20 @@ func (h *LoginHandler) handleLoginWithProvider(payload *router.Payload, p *login
 			payload.DBConn, payload.Database, h.AssetStore, h.HookRegistry, payload.Context,
 		}
 
-		if err = createContext.execute(authinfo, *authdata); err != nil {
+		createdUser, err := createContext.execute(authinfo, skydb.AuthData{})
+		if err != nil {
 			return skyerr.MakeError(err)
 		}
+
+		*user = *createdUser
 	} else {
 		authinfo.SetProviderInfoData(principalID, providerAuthData)
 		if err := payload.DBConn.UpdateAuth(authinfo); err != nil {
+			return skyerr.MakeError(err)
+		}
+
+		err := payload.Database.Get(skydb.NewRecordID("user", authinfo.ID), user)
+		if err != nil {
 			return skyerr.MakeError(err)
 		}
 	}
@@ -337,30 +358,29 @@ func (h *LoginHandler) handleLoginWithProvider(payload *router.Payload, p *login
 	return nil
 }
 
-func (h *LoginHandler) handleLoginWithAuthData(payload *router.Payload, p *loginPayload, authinfo *skydb.AuthInfo, authdata *skydb.AuthData) skyerr.Error {
-	*authdata = skydb.AuthData{}
-	authdata.SetUsername(p.Username)
-	authdata.SetEmail(p.Email)
+func (h *LoginHandler) handleLoginWithAuthData(payload *router.Payload, p *loginPayload, authinfo *skydb.AuthInfo, user *skydb.Record) skyerr.Error {
+	authdata := p.AuthData
 
 	if ok := authdata.IsValid(); !ok {
 		return skyerr.NewInvalidArgument("Unexpected key found", []string{"authdata"})
 	}
 
 	fetcher := newUserAuthFetcher(payload.Database, payload.DBConn)
-	fetchedAuthInfo, _, err := fetcher.FetchAuth(*authdata)
+	fetchedAuthInfo, fetchedUser, err := fetcher.FetchAuth(authdata)
 	if err != nil {
 		if err == skydb.ErrUserNotFound {
 			return skyerr.NewError(skyerr.ResourceNotFound, "user not found")
 		}
 
 		// TODO: more error handling here if necessary
-		return skyerr.NewResourceFetchFailureErr("user", p.Username)
+		return skyerr.NewResourceFetchFailureErr("auth_data", p.AuthData)
 	}
 
 	*authinfo = fetchedAuthInfo
+	*user = fetchedUser
 
 	if !authinfo.IsSamePassword(p.Password) {
-		return skyerr.NewError(skyerr.InvalidCredentials, "username or password incorrect")
+		return skyerr.NewError(skyerr.InvalidCredentials, "auth_data or password incorrect")
 	}
 
 	return nil

--- a/pkg/server/handler/auth_test.go
+++ b/pkg/server/handler/auth_test.go
@@ -45,17 +45,7 @@ func tempDir() string {
 	return dir
 }
 
-func makeEqualPredicate(keyPath string, value string) skydb.Predicate {
-	return skydb.Predicate{
-		Operator: skydb.Equal,
-		Children: []interface{}{
-			skydb.Expression{Type: skydb.KeyPath, Value: keyPath},
-			skydb.Expression{Type: skydb.Literal, Value: value},
-		},
-	}
-}
-
-func makeEqualPredicateAssertion(key string, value string) func(predicate *skydb.Predicate) {
+func MakeEqualPredicateAssertion(key string, value string) func(predicate *skydb.Predicate) {
 	return func(predicate *skydb.Predicate) {
 		So(predicate.Operator, ShouldEqual, skydb.Equal)
 
@@ -70,7 +60,7 @@ func makeEqualPredicateAssertion(key string, value string) func(predicate *skydb
 	}
 }
 
-func makeUsernameEmailQueryAssertion(username string, email string) func(query *skydb.Query) {
+func MakeUsernameEmailQueryAssertion(username string, email string) func(query *skydb.Query) {
 	return func(query *skydb.Query) {
 		So(query.Type, ShouldEqual, "user")
 
@@ -92,9 +82,9 @@ func makeUsernameEmailQueryAssertion(username string, email string) func(query *
 			childPredicate := child.(skydb.Predicate)
 			keyExp := childPredicate.Children[0].(skydb.Expression)
 			if keyExp.Type == skydb.KeyPath && keyExp.Value == "username" {
-				makeEqualPredicateAssertion("username", username)(&childPredicate)
+				MakeEqualPredicateAssertion("username", username)(&childPredicate)
 			} else if keyExp.Type == skydb.KeyPath && keyExp.Value == "email" {
-				makeEqualPredicateAssertion("email", email)(&childPredicate)
+				MakeEqualPredicateAssertion("email", email)(&childPredicate)
 			} else {
 				panic(fmt.Sprintf("Unexpected keypath"))
 			}
@@ -102,7 +92,7 @@ func makeUsernameEmailQueryAssertion(username string, email string) func(query *
 	}
 }
 
-func makeUserRecordAssertion(authData skydb.AuthData) func(record *skydb.Record) {
+func MakeUserRecordAssertion(authData skydb.AuthData) func(record *skydb.Record) {
 	return func(record *skydb.Record) {
 		So(record.ID.Type, ShouldEqual, "user")
 		So(record.Data["username"], ShouldEqual, authData["username"])
@@ -110,11 +100,25 @@ func makeUserRecordAssertion(authData skydb.AuthData) func(record *skydb.Record)
 	}
 }
 
+func ExpectDBSaveUserWithAuthData(db *mock_skydb.MockTxDatabase, authData skydb.AuthData) {
+	userRecordSchema := skydb.RecordSchema{
+		"username": skydb.FieldType{Type: skydb.TypeString},
+		"email":    skydb.FieldType{Type: skydb.TypeString},
+	}
+	skydbtest.ExpectDBSaveUser(db, userRecordSchema, MakeUserRecordAssertion(authData))
+}
+
 // Seems like a memory imlementation of skydb will make tests
 // faster and easier
 
 func TestSignupHandler(t *testing.T) {
 	Convey("SignupHandler", t, func() {
+		realTime := timeNow
+		timeNow = func() time.Time { return time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC) }
+		defer func() {
+			timeNow = realTime
+		}()
+
 		conn := skydbtest.NewMapConn()
 		tokenStore := authtokentest.SingleTokenStore{}
 
@@ -126,48 +130,23 @@ func TestSignupHandler(t *testing.T) {
 			TokenStore: &tokenStore,
 		}
 
-		expectDBSaveUser := func(db *mock_skydb.MockTxDatabase, authData skydb.AuthData) {
-			db.EXPECT().UserRecordType().Return("user").AnyTimes()
-			db.EXPECT().ID().Return("_public").AnyTimes()
-
-			// no record found
-			db.EXPECT().
-				Get(gomock.Any(), gomock.Any()).
-				Return(skydb.ErrRecordNotFound).
-				AnyTimes()
-
-			userRecordSchema := skydb.RecordSchema{
-				"username": skydb.FieldType{Type: skydb.TypeString},
-				"email":    skydb.FieldType{Type: skydb.TypeString},
-			}
-
-			// extend Schema
-			db.EXPECT().GetSchema("user").Return(skydb.RecordSchema{}, nil).AnyTimes()
-			db.EXPECT().Extend("user", userRecordSchema).Return(true, nil).AnyTimes()
-
-			db.EXPECT().
-				Save(gomock.Any()).
-				Do(makeUserRecordAssertion(authData)).
-				Return(nil).
-				AnyTimes()
-		}
-
 		Convey("sign up new account", func() {
-			fmt.Println("sign up new account")
 			db.EXPECT().
 				Query(gomock.Any()).
-				Do(makeUsernameEmailQueryAssertion("john.doe", "john.doe@example.com")).
+				Do(MakeUsernameEmailQueryAssertion("john.doe", "john.doe@example.com")).
 				Return(skydb.NewRows(skydb.NewMemoryRows([]skydb.Record{})), nil).
 				AnyTimes()
 			txBegin := db.EXPECT().Begin().AnyTimes()
 			db.EXPECT().Commit().After(txBegin)
 
-			expectDBSaveUser(db, skydb.AuthData{"username": "john.doe", "email": "john.doe@example.com"})
+			ExpectDBSaveUserWithAuthData(db, skydb.AuthData{"username": "john.doe", "email": "john.doe@example.com"})
 
 			req := router.Payload{
 				Data: map[string]interface{}{
-					"username": "john.doe",
-					"email":    "john.doe@example.com",
+					"auth_data": skydb.AuthData{
+						"username": "john.doe",
+						"email":    "john.doe@example.com",
+					},
 					"password": "secret",
 				},
 				DBConn:   conn,
@@ -178,8 +157,17 @@ func TestSignupHandler(t *testing.T) {
 
 			So(resp.Result, ShouldHaveSameTypeAs, AuthResponse{})
 			authResp := resp.Result.(AuthResponse)
-			So(authResp.Username, ShouldEqual, "john.doe")
-			So(authResp.Email, ShouldEqual, "john.doe@example.com")
+			So(authResp.User.ID, ShouldResemble, skydb.NewRecordID("user", authResp.UserID))
+			So(authResp.User.DatabaseID, ShouldResemble, "_public")
+			So(authResp.User.OwnerID, ShouldResemble, authResp.UserID)
+			So(authResp.User.CreatorID, ShouldResemble, authResp.UserID)
+			So(authResp.User.UpdaterID, ShouldResemble, authResp.UserID)
+			So(authResp.User.CreatedAt, ShouldResemble, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC))
+			So(authResp.User.UpdatedAt, ShouldResemble, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC))
+			So(authResp.User.Data, ShouldResemble, skydb.Data{
+				"username": "john.doe",
+				"email":    "john.doe@example.com",
+			})
 			So(authResp.AccessToken, ShouldNotBeEmpty)
 			So(authResp.LastLoginAt, ShouldNotBeEmpty)
 			So(authResp.LastSeenAt, ShouldNotBeEmpty)
@@ -193,6 +181,25 @@ func TestSignupHandler(t *testing.T) {
 			So(authinfo.Roles, ShouldBeNil)
 		})
 
+		Convey("sign up with invalid auth data", func() {
+			req := router.Payload{
+				Data: map[string]interface{}{
+					"auth_data": skydb.AuthData{
+						"iamyourfather": "john.doe",
+					},
+					"password": "secret",
+				},
+				DBConn:   conn,
+				Database: db,
+			}
+			resp := router.Response{}
+			handler.Handle(&req, &resp)
+
+			So(resp.Err, ShouldImplement, (*skyerr.Error)(nil))
+			errorResponse := resp.Err.(skyerr.Error)
+			So(errorResponse.Code(), ShouldEqual, skyerr.InvalidArgument)
+		})
+
 		Convey("sign up new account with role base access control will have default role", func() {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -200,18 +207,20 @@ func TestSignupHandler(t *testing.T) {
 			db := mock_skydb.NewMockTxDatabase(ctrl)
 			db.EXPECT().
 				Query(gomock.Any()).
-				Do(makeUsernameEmailQueryAssertion("john.doe", "john.doe@example.com")).
+				Do(MakeUsernameEmailQueryAssertion("john.doe", "john.doe@example.com")).
 				Return(skydb.NewRows(skydb.NewMemoryRows([]skydb.Record{})), nil).
 				AnyTimes()
 			txBegin := db.EXPECT().Begin().AnyTimes()
 			db.EXPECT().Commit().After(txBegin)
 
-			expectDBSaveUser(db, skydb.AuthData{"username": "john.doe", "email": "john.doe@example.com"})
+			ExpectDBSaveUserWithAuthData(db, skydb.AuthData{"username": "john.doe", "email": "john.doe@example.com"})
 
 			req := router.Payload{
 				Data: map[string]interface{}{
-					"username": "john.doe",
-					"email":    "john.doe@example.com",
+					"auth_data": skydb.AuthData{
+						"username": "john.doe",
+						"email":    "john.doe@example.com",
+					},
 					"password": "secret",
 				},
 				DBConn:   conn,
@@ -236,7 +245,7 @@ func TestSignupHandler(t *testing.T) {
 			conn.CreateAuth(&authinfo)
 			db.EXPECT().
 				Query(gomock.Any()).
-				Do(makeUsernameEmailQueryAssertion("john.doe", "john.doe@example.com")).
+				Do(MakeUsernameEmailQueryAssertion("john.doe", "john.doe@example.com")).
 				Return(skydb.NewRows(skydb.NewMemoryRows([]skydb.Record{
 					skydb.Record{
 						ID: skydb.NewRecordID("user", authinfo.ID),
@@ -252,8 +261,10 @@ func TestSignupHandler(t *testing.T) {
 
 			req := router.Payload{
 				Data: map[string]interface{}{
-					"username": "john.doe",
-					"email":    "john.doe@example.com",
+					"auth_data": skydb.AuthData{
+						"username": "john.doe",
+						"email":    "john.doe@example.com",
+					},
 					"password": "secret",
 				},
 				DBConn:   conn,
@@ -272,7 +283,7 @@ func TestSignupHandler(t *testing.T) {
 			conn.CreateAuth(&authinfo)
 			db.EXPECT().
 				Query(gomock.Any()).
-				Do(makeUsernameEmailQueryAssertion("john.doe", "john.doe@example.com")).
+				Do(MakeUsernameEmailQueryAssertion("john.doe", "john.doe@example.com")).
 				Return(skydb.NewRows(skydb.NewMemoryRows([]skydb.Record{
 					skydb.Record{
 						ID: skydb.NewRecordID("user", authinfo.ID),
@@ -288,8 +299,10 @@ func TestSignupHandler(t *testing.T) {
 
 			req := router.Payload{
 				Data: map[string]interface{}{
-					"username": "john.doe",
-					"email":    "john.doe@example.com",
+					"auth_data": skydb.AuthData{
+						"username": "john.doe",
+						"email":    "john.doe@example.com",
+					},
 					"password": "secret",
 				},
 				DBConn:   conn,
@@ -307,6 +320,12 @@ func TestSignupHandler(t *testing.T) {
 
 func TestLoginHandler(t *testing.T) {
 	Convey("LoginHandler", t, func() {
+		realTime := timeNow
+		timeNow = func() time.Time { return time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC) }
+		defer func() {
+			timeNow = realTime
+		}()
+
 		conn := skydbtest.NewMapConn()
 
 		ctrl := gomock.NewController(t)
@@ -328,7 +347,7 @@ func TestLoginHandler(t *testing.T) {
 
 			db.EXPECT().
 				Query(gomock.Any()).
-				Do(makeUsernameEmailQueryAssertion("john.doe", "")).
+				Do(MakeUsernameEmailQueryAssertion("john.doe", "")).
 				Return(skydb.NewRows(skydb.NewMemoryRows([]skydb.Record{skydb.Record{
 					ID:   skydb.NewRecordID("user", authinfo.ID),
 					Data: map[string]interface{}{"username": "john.doe", "email": "john.doe@example.com"},
@@ -337,7 +356,9 @@ func TestLoginHandler(t *testing.T) {
 
 			req := router.Payload{
 				Data: map[string]interface{}{
-					"username": "john.doe",
+					"auth_data": skydb.AuthData{
+						"username": "john.doe",
+					},
 					"password": "secret",
 				},
 				DBConn:   conn,
@@ -349,8 +370,11 @@ func TestLoginHandler(t *testing.T) {
 			So(resp.Result, ShouldHaveSameTypeAs, AuthResponse{})
 
 			authResp := resp.Result.(AuthResponse)
-			So(authResp.Username, ShouldEqual, "john.doe")
-			So(authResp.Email, ShouldEqual, "john.doe@example.com")
+			So(authResp.User.ID, ShouldResemble, skydb.NewRecordID("user", authResp.UserID))
+			So(authResp.User.Data, ShouldResemble, skydb.Data{
+				"username": "john.doe",
+				"email":    "john.doe@example.com",
+			})
 			So(authResp.AccessToken, ShouldNotBeEmpty)
 			So(authResp.Roles, ShouldContain, "Programmer")
 			So(authResp.Roles, ShouldContain, "Tester")
@@ -360,22 +384,12 @@ func TestLoginHandler(t *testing.T) {
 			So(token.AccessToken, ShouldNotBeEmpty)
 		})
 
-		Convey("login user with username in different case should ok", func() {
-			authinfo := skydb.NewAuthInfo("secret")
-			conn.CreateAuth(&authinfo)
-
-			db.EXPECT().
-				Query(gomock.Any()).
-				Do(makeUsernameEmailQueryAssertion("john.DOE", "")).
-				Return(skydb.NewRows(skydb.NewMemoryRows([]skydb.Record{skydb.Record{
-					ID:   skydb.NewRecordID("user", authinfo.ID),
-					Data: map[string]interface{}{"username": "john.doe", "email": "john.doe@example.com"},
-				}})), nil).
-				AnyTimes()
-
+		Convey("login with invalid auth data", func() {
 			req := router.Payload{
 				Data: map[string]interface{}{
-					"username": "john.DOE",
+					"auth_data": skydb.AuthData{
+						"iamyourfather": "john.doe",
+					},
 					"password": "secret",
 				},
 				DBConn:   conn,
@@ -384,56 +398,18 @@ func TestLoginHandler(t *testing.T) {
 			resp := router.Response{}
 			handler.Handle(&req, &resp)
 
-			So(resp.Result, ShouldHaveSameTypeAs, AuthResponse{})
-			authResp := resp.Result.(AuthResponse)
-			So(authResp.Username, ShouldEqual, "john.doe")
-			So(authResp.Email, ShouldEqual, "john.doe@example.com")
-			So(authResp.AccessToken, ShouldNotBeEmpty)
-			token := tokenStore.Token
-			So(token.AuthInfoID, ShouldEqual, authResp.UserID)
-			So(token.AccessToken, ShouldNotBeEmpty)
+			So(resp.Err, ShouldImplement, (*skyerr.Error)(nil))
+			errorResponse := resp.Err.(skyerr.Error)
+			So(errorResponse.Code(), ShouldEqual, skyerr.InvalidArgument)
 		})
 
-		Convey("login user with email in different case should ok", func() {
-			authinfo := skydb.NewAuthInfo("secret")
-			conn.CreateAuth(&authinfo)
-
-			db.EXPECT().
-				Query(gomock.Any()).
-				Do(makeUsernameEmailQueryAssertion("", "john.DOE@example.com")).
-				Return(skydb.NewRows(skydb.NewMemoryRows([]skydb.Record{skydb.Record{
-					ID:   skydb.NewRecordID("user", authinfo.ID),
-					Data: map[string]interface{}{"username": "john.doe", "email": "john.doe@example.com"},
-				}})), nil).
-				AnyTimes()
-
-			req := router.Payload{
-				Data: map[string]interface{}{
-					"email":    "john.DOE@example.com",
-					"password": "secret",
-				},
-				DBConn:   conn,
-				Database: db,
-			}
-			resp := router.Response{}
-			handler.Handle(&req, &resp)
-
-			So(resp.Result, ShouldHaveSameTypeAs, AuthResponse{})
-			authResp := resp.Result.(AuthResponse)
-			So(authResp.Username, ShouldEqual, "john.doe")
-			So(authResp.Email, ShouldEqual, "john.doe@example.com")
-			So(authResp.AccessToken, ShouldNotBeEmpty)
-			token := tokenStore.Token
-			So(token.AuthInfoID, ShouldEqual, authResp.UserID)
-			So(token.AccessToken, ShouldNotBeEmpty)
-		})
 		Convey("login user wrong password", func() {
 			authinfo := skydb.NewAuthInfo("secret")
 			conn.CreateAuth(&authinfo)
 
 			db.EXPECT().
 				Query(gomock.Any()).
-				Do(makeUsernameEmailQueryAssertion("john.doe", "")).
+				Do(MakeUsernameEmailQueryAssertion("john.doe", "")).
 				Return(skydb.NewRows(skydb.NewMemoryRows([]skydb.Record{skydb.Record{
 					ID:   skydb.NewRecordID("user", authinfo.ID),
 					Data: map[string]interface{}{"username": "john.doe", "email": "john.doe@example.com"},
@@ -442,7 +418,9 @@ func TestLoginHandler(t *testing.T) {
 
 			req := router.Payload{
 				Data: map[string]interface{}{
-					"username": "john.doe",
+					"auth_data": skydb.AuthData{
+						"username": "john.doe",
+					},
 					"password": "wrongsecret",
 				},
 				DBConn:   conn,
@@ -459,13 +437,15 @@ func TestLoginHandler(t *testing.T) {
 		Convey("login user not found", func() {
 			db.EXPECT().
 				Query(gomock.Any()).
-				Do(makeUsernameEmailQueryAssertion("john.doe", "")).
+				Do(MakeUsernameEmailQueryAssertion("john.doe", "")).
 				Return(skydb.NewRows(skydb.NewMemoryRows([]skydb.Record{})), nil).
 				AnyTimes()
 
 			req := router.Payload{
 				Data: map[string]interface{}{
-					"username": "john.doe",
+					"auth_data": skydb.AuthData{
+						"username": "john.doe",
+					},
 					"password": "secret",
 				},
 				DBConn:   conn,
@@ -483,6 +463,12 @@ func TestLoginHandler(t *testing.T) {
 
 func TestLoginHandlerWithProvider(t *testing.T) {
 	Convey("LoginHandler", t, func() {
+		realTime := timeNow
+		timeNow = func() time.Time { return time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC) }
+		defer func() {
+			timeNow = realTime
+		}()
+
 		tokenStore := authtokentest.SingleTokenStore{}
 		conn := singleUserConn{}
 		db := skydbtest.NewMapDB()
@@ -521,6 +507,17 @@ func TestLoginHandlerWithProvider(t *testing.T) {
 				conn.authinfo = nil
 			}()
 
+			db.Save(&skydb.Record{
+				ID:         skydb.NewRecordID("user", authinfo.ID),
+				DatabaseID: db.ID(),
+				OwnerID:    authinfo.ID,
+				CreatorID:  authinfo.ID,
+				UpdaterID:  authinfo.ID,
+				CreatedAt:  n,
+				UpdatedAt:  n,
+				Data:       map[string]interface{}{},
+			})
+
 			resp := r.POST(`{"provider": "com.example", "provider_auth_data": {"name": "johndoe"}}`)
 
 			token := tokenStore.Token
@@ -532,11 +529,25 @@ func TestLoginHandlerWithProvider(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, fmt.Sprintf(`{
 	"result": {
 		"user_id": "%v",
+		"user": {
+			"_type": "record",
+			"_id": "user/%v",
+			"_created_by": "%v",
+			"_ownerID": "%v",
+			"_updated_by": "%v",
+			"_access": null,
+			"_created_at": "2006-01-02T15:04:05Z",
+			"_updated_at": "2006-01-02T15:04:05Z"
+		},
 		"access_token": "%v",
 		"last_login_at": "%v",
 		"last_seen_at": "%v"
 	}
 }`,
+				authinfo.ID,
+				authinfo.ID,
+				authinfo.ID,
+				authinfo.ID,
 				authinfo.ID,
 				token.AccessToken,
 				n.Format(time.RFC3339Nano),
@@ -564,9 +575,23 @@ func TestLoginHandlerWithProvider(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, fmt.Sprintf(`{
 	"result": {
 		"user_id": "%v",
+		"user": {
+			"_type": "record",
+			"_id": "user/%v",
+			"_created_by": "%v",
+			"_ownerID": "%v",
+			"_updated_by": "%v",
+			"_access": null,
+			"_created_at": "2006-01-02T15:04:05Z",
+			"_updated_at": "2006-01-02T15:04:05Z"
+		},
 		"access_token": "%v"
 	}
 }`,
+				authinfo.ID,
+				authinfo.ID,
+				authinfo.ID,
+				authinfo.ID,
 				authinfo.ID,
 				token.AccessToken,
 			))
@@ -630,6 +655,12 @@ func (conn *singleUserConn) GetRecordFieldAccess() (skydb.FieldACL, error) {
 
 func TestSignupHandlerAsAnonymous(t *testing.T) {
 	Convey("SignupHandler", t, func() {
+		realTime := timeNow
+		timeNow = func() time.Time { return time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC) }
+		defer func() {
+			timeNow = realTime
+		}()
+
 		tokenStore := authtokentest.SingleTokenStore{}
 		conn := singleUserConn{}
 		db := skydbtest.NewMapDB()
@@ -656,11 +687,25 @@ func TestSignupHandlerAsAnonymous(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, fmt.Sprintf(`{
 	"result": {
 		"user_id": "%v",
+		"user": {
+			"_type": "record",
+			"_id": "user/%v",
+			"_created_by": "%v",
+			"_ownerID": "%v",
+			"_updated_by": "%v",
+			"_access": null,
+			"_created_at": "2006-01-02T15:04:05Z",
+			"_updated_at": "2006-01-02T15:04:05Z"
+		},
 		"access_token": "%v",
 		"last_login_at": "%v",
 		"last_seen_at": "%v"
 	}
 }`,
+				authinfo.ID,
+				authinfo.ID,
+				authinfo.ID,
+				authinfo.ID,
 				authinfo.ID,
 				token.AccessToken,
 				authinfo.LastLoginAt.Format(time.RFC3339Nano),
@@ -681,8 +726,8 @@ func TestSignupHandlerAsAnonymous(t *testing.T) {
 	"error": {
 		"code": 108,
 		"name": "InvalidArgument",
-		"info": {"arguments": ["username","email"]},
-		"message": "empty username and empty email"
+		"info": {"arguments": ["auth_data"]},
+		"message": "invalid auth data"
 	}
 }`)
 			So(resp.Code, ShouldEqual, 400)
@@ -690,8 +735,10 @@ func TestSignupHandlerAsAnonymous(t *testing.T) {
 
 		Convey("errors when password is missing", func() {
 			resp := r.POST(`{
-				"username": "john.doe",
-				"email": "john.doe@example.com"
+				"auth_data": {
+					"username": "john.doe",
+					"email": "john.doe@example.com"
+				}
 }`)
 			So(resp.Body.Bytes(), ShouldEqualJSON, `{
 	"error": {
@@ -708,6 +755,12 @@ func TestSignupHandlerAsAnonymous(t *testing.T) {
 
 func TestSignupHandlerWithProvider(t *testing.T) {
 	Convey("SignupHandler", t, func() {
+		realTime := timeNow
+		timeNow = func() time.Time { return time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC) }
+		defer func() {
+			timeNow = realTime
+		}()
+
 		tokenStore := authtokentest.SingleTokenStore{}
 		conn := singleUserConn{}
 		db := skydbtest.NewMapDB()
@@ -752,11 +805,25 @@ func TestSignupHandlerWithProvider(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, fmt.Sprintf(`{
 	"result": {
 		"user_id": "%v",
+		"user": {
+			"_type": "record",
+			"_id": "user/%v",
+			"_created_by": "%v",
+			"_ownerID": "%v",
+			"_updated_by": "%v",
+			"_access": null,
+			"_created_at": "2006-01-02T15:04:05Z",
+			"_updated_at": "2006-01-02T15:04:05Z"
+		},
 		"access_token": "%v",
 		"last_login_at": "%v",
 		"last_seen_at": "%v"
 	}
 }`,
+				authinfo.ID,
+				authinfo.ID,
+				authinfo.ID,
+				authinfo.ID,
 				authinfo.ID,
 				token.AccessToken,
 				authinfo.LastLoginAt.Format(time.RFC3339Nano),

--- a/pkg/server/handler/auth_test.go
+++ b/pkg/server/handler/auth_test.go
@@ -157,14 +157,14 @@ func TestSignupHandler(t *testing.T) {
 
 			So(resp.Result, ShouldHaveSameTypeAs, AuthResponse{})
 			authResp := resp.Result.(AuthResponse)
-			So(authResp.User.ID, ShouldResemble, skydb.NewRecordID("user", authResp.UserID))
-			So(authResp.User.DatabaseID, ShouldResemble, "_public")
-			So(authResp.User.OwnerID, ShouldResemble, authResp.UserID)
-			So(authResp.User.CreatorID, ShouldResemble, authResp.UserID)
-			So(authResp.User.UpdaterID, ShouldResemble, authResp.UserID)
-			So(authResp.User.CreatedAt, ShouldResemble, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC))
-			So(authResp.User.UpdatedAt, ShouldResemble, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC))
-			So(authResp.User.Data, ShouldResemble, skydb.Data{
+			So(authResp.Profile.ID, ShouldResemble, skydb.NewRecordID("user", authResp.UserID))
+			So(authResp.Profile.DatabaseID, ShouldResemble, "_public")
+			So(authResp.Profile.OwnerID, ShouldResemble, authResp.UserID)
+			So(authResp.Profile.CreatorID, ShouldResemble, authResp.UserID)
+			So(authResp.Profile.UpdaterID, ShouldResemble, authResp.UserID)
+			So(authResp.Profile.CreatedAt, ShouldResemble, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC))
+			So(authResp.Profile.UpdatedAt, ShouldResemble, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC))
+			So(authResp.Profile.Data, ShouldResemble, skydb.Data{
 				"username": "john.doe",
 				"email":    "john.doe@example.com",
 			})
@@ -370,8 +370,8 @@ func TestLoginHandler(t *testing.T) {
 			So(resp.Result, ShouldHaveSameTypeAs, AuthResponse{})
 
 			authResp := resp.Result.(AuthResponse)
-			So(authResp.User.ID, ShouldResemble, skydb.NewRecordID("user", authResp.UserID))
-			So(authResp.User.Data, ShouldResemble, skydb.Data{
+			So(authResp.Profile.ID, ShouldResemble, skydb.NewRecordID("user", authResp.UserID))
+			So(authResp.Profile.Data, ShouldResemble, skydb.Data{
 				"username": "john.doe",
 				"email":    "john.doe@example.com",
 			})
@@ -529,7 +529,7 @@ func TestLoginHandlerWithProvider(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, fmt.Sprintf(`{
 	"result": {
 		"user_id": "%v",
-		"user": {
+		"profile": {
 			"_type": "record",
 			"_id": "user/%v",
 			"_created_by": "%v",
@@ -575,7 +575,7 @@ func TestLoginHandlerWithProvider(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, fmt.Sprintf(`{
 	"result": {
 		"user_id": "%v",
-		"user": {
+		"profile": {
 			"_type": "record",
 			"_id": "user/%v",
 			"_created_by": "%v",
@@ -687,7 +687,7 @@ func TestSignupHandlerAsAnonymous(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, fmt.Sprintf(`{
 	"result": {
 		"user_id": "%v",
-		"user": {
+		"profile": {
 			"_type": "record",
 			"_id": "user/%v",
 			"_created_by": "%v",
@@ -805,7 +805,7 @@ func TestSignupHandlerWithProvider(t *testing.T) {
 			So(resp.Body.Bytes(), ShouldEqualJSON, fmt.Sprintf(`{
 	"result": {
 		"user_id": "%v",
-		"user": {
+		"profile": {
 			"_type": "record",
 			"_id": "user/%v",
 			"_created_by": "%v",

--- a/pkg/server/handler/common.go
+++ b/pkg/server/handler/common.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/skygeario/skygear-server/pkg/server/asset"
+	"github.com/skygeario/skygear-server/pkg/server/recordutil"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
-	"github.com/skygeario/skygear-server/pkg/server/skydb/recordutil"
 	"github.com/skygeario/skygear-server/pkg/server/skydb/skyconv"
 	"github.com/skygeario/skygear-server/pkg/server/uuid"
 )

--- a/pkg/server/handler/common.go
+++ b/pkg/server/handler/common.go
@@ -41,11 +41,12 @@ type AuthResponse struct {
 }
 
 type AuthResponseFactory struct {
-	AssetStore asset.Store `inject:"AssetStore"`
+	AssetStore asset.Store
+	Conn       skydb.Conn
 }
 
-func (f AuthResponseFactory) NewAuthResponse(conn skydb.Conn, info skydb.AuthInfo, user skydb.Record, accessToken string) (AuthResponse, error) {
-	filter, err := recordutil.NewRecordResultFilter(conn, f.AssetStore, &info)
+func (f AuthResponseFactory) NewAuthResponse(info skydb.AuthInfo, user skydb.Record, accessToken string) (AuthResponse, error) {
+	filter, err := recordutil.NewRecordResultFilter(f.Conn, f.AssetStore, &info)
 	if err != nil {
 		return AuthResponse{}, err
 	}

--- a/pkg/server/handler/common.go
+++ b/pkg/server/handler/common.go
@@ -33,7 +33,7 @@ var (
 // AuthResponse is the unify way of returing a AuthInfo with AuthData to SDK
 type AuthResponse struct {
 	UserID      string              `json:"user_id,omitempty"`
-	User        *skyconv.JSONRecord `json:"user,omitempty"`
+	Profile     *skyconv.JSONRecord `json:"profile,omitempty"`
 	Roles       []string            `json:"roles,omitempty"`
 	AccessToken string              `json:"access_token,omitempty"`
 	LastLoginAt *time.Time          `json:"last_login_at,omitempty"`
@@ -55,7 +55,7 @@ func (f AuthResponseFactory) NewAuthResponse(info skydb.AuthInfo, user skydb.Rec
 
 	return AuthResponse{
 		UserID:      info.ID,
-		User:        jsonUser,
+		Profile:     jsonUser,
 		Roles:       info.Roles,
 		AccessToken: accessToken,
 		LastLoginAt: info.LastLoginAt,

--- a/pkg/server/handler/device.go
+++ b/pkg/server/handler/device.go
@@ -106,7 +106,7 @@ type DeviceReigsterResult struct {
 type DeviceRegisterHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
 	RequireUser   router.Processor `preprocessor:"require_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
@@ -117,7 +117,7 @@ func (h *DeviceRegisterHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.RequireUser,
 		h.PluginReady,
@@ -203,7 +203,7 @@ func (h *DeviceRegisterHandler) Handle(rpayload *router.Payload, response *route
 type DeviceUnregisterHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
 	RequireUser   router.Processor `preprocessor:"require_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
@@ -214,7 +214,7 @@ func (h *DeviceUnregisterHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.RequireUser,
 		h.PluginReady,

--- a/pkg/server/handler/me.go
+++ b/pkg/server/handler/me.go
@@ -26,8 +26,8 @@ type MeHandler struct {
 	TokenStore    authtoken.Store  `inject:"TokenStore"`
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
+	InjectUser    router.Processor `preprocessor:"inject_user"`
 	InjectAuth    router.Processor `preprocessor:"inject_auth"`
-	InjectDB      router.Processor `preprocessor:"inject_public_db"`
 	RequireUser   router.Processor `preprocessor:"require_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
@@ -38,8 +38,8 @@ func (h *MeHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
+		h.InjectUser,
 		h.InjectAuth,
-		h.InjectDB,
 		h.RequireUser,
 		h.PluginReady,
 	}
@@ -87,9 +87,9 @@ func (h *MeHandler) Handle(payload *router.Payload, response *router.Response) {
 		panic(err)
 	}
 
-	user := skydb.Record{}
-	if err = payload.Database.Get(skydb.NewRecordID("user", info.ID), &user); err != nil {
-		panic(err)
+	user := payload.User
+	if user == nil {
+		panic("user record not found")
 	}
 
 	authData := skydb.AuthData{}

--- a/pkg/server/handler/me.go
+++ b/pkg/server/handler/me.go
@@ -26,7 +26,7 @@ type MeHandler struct {
 	TokenStore    authtoken.Store  `inject:"TokenStore"`
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_public_db"`
 	RequireUser   router.Processor `preprocessor:"require_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
@@ -38,7 +38,7 @@ func (h *MeHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.RequireUser,
 		h.PluginReady,

--- a/pkg/server/handler/me.go
+++ b/pkg/server/handler/me.go
@@ -15,6 +15,7 @@
 package handler
 
 import (
+	"github.com/skygeario/skygear-server/pkg/server/asset"
 	"github.com/skygeario/skygear-server/pkg/server/authtoken"
 	"github.com/skygeario/skygear-server/pkg/server/router"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
@@ -23,6 +24,7 @@ import (
 // MeHandler handles the me request
 type MeHandler struct {
 	TokenStore    authtoken.Store  `inject:"TokenStore"`
+	AssetStore    asset.Store      `inject:"AssetStore"`
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectUser    router.Processor `preprocessor:"inject_user"`
@@ -92,7 +94,10 @@ func (h *MeHandler) Handle(payload *router.Payload, response *router.Response) {
 	}
 
 	// We will return the last seen in DB, not current time stamp
-	authResponse, err := AuthResponseFactory{}.NewAuthResponse(payload.DBConn, *info, *user, token.AccessToken)
+	authResponse, err := AuthResponseFactory{
+		AssetStore: h.AssetStore,
+		Conn:       payload.DBConn,
+	}.NewAuthResponse(*info, *user, token.AccessToken)
 	if err != nil {
 		response.Err = skyerr.MakeError(err)
 		return

--- a/pkg/server/handler/me_test.go
+++ b/pkg/server/handler/me_test.go
@@ -73,8 +73,13 @@ func TestMeHandler(t *testing.T) {
         "result": {
           "access_token": "%s",
           "user_id": "tester-1",
-          "email": "tester1@example.com",
-          "username": "tester1",
+          "user": {
+            "_type": "record",
+            "_id": "user/tester-1",
+            "_access": null,
+            "email": "tester1@example.com",
+            "username": "tester1"
+          },
           "roles": ["Test", "Programmer"],
           "last_login_at": "%v",
           "last_seen_at": "%v"

--- a/pkg/server/handler/me_test.go
+++ b/pkg/server/handler/me_test.go
@@ -73,7 +73,7 @@ func TestMeHandler(t *testing.T) {
         "result": {
           "access_token": "%s",
           "user_id": "tester-1",
-          "user": {
+          "profile": {
             "_type": "record",
             "_id": "user/tester-1",
             "_access": null,

--- a/pkg/server/handler/record.go
+++ b/pkg/server/handler/record.go
@@ -245,7 +245,7 @@ type RecordSaveHandler struct {
 	EventSender   pluginEvent.Sender `inject:"PluginEventSender"`
 	Authenticator router.Processor   `preprocessor:"authenticator"`
 	DBConn        router.Processor   `preprocessor:"dbconn"`
-	InjectUser    router.Processor   `preprocessor:"inject_user"`
+	InjectAuth    router.Processor   `preprocessor:"inject_auth"`
 	InjectDB      router.Processor   `preprocessor:"inject_db"`
 	RequireUser   router.Processor   `preprocessor:"require_user"`
 	PluginReady   router.Processor   `preprocessor:"plugin_ready"`
@@ -256,7 +256,7 @@ func (h *RecordSaveHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.RequireUser,
 		h.PluginReady,
@@ -416,7 +416,7 @@ type RecordFetchHandler struct {
 	AccessModel   skydb.AccessModel `inject:"AccessModel"`
 	Authenticator router.Processor  `preprocessor:"authenticator"`
 	DBConn        router.Processor  `preprocessor:"dbconn"`
-	InjectUser    router.Processor  `preprocessor:"inject_user"`
+	InjectAuth    router.Processor  `preprocessor:"inject_auth"`
 	InjectDB      router.Processor  `preprocessor:"inject_db"`
 	PluginReady   router.Processor  `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
@@ -426,7 +426,7 @@ func (h *RecordFetchHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.PluginReady,
 	}
@@ -510,7 +510,7 @@ type RecordQueryHandler struct {
 	AccessModel   skydb.AccessModel `inject:"AccessModel"`
 	Authenticator router.Processor  `preprocessor:"authenticator"`
 	DBConn        router.Processor  `preprocessor:"dbconn"`
-	InjectUser    router.Processor  `preprocessor:"inject_user"`
+	InjectAuth    router.Processor  `preprocessor:"inject_auth"`
 	InjectDB      router.Processor  `preprocessor:"inject_db"`
 	PluginReady   router.Processor  `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
@@ -520,7 +520,7 @@ func (h *RecordQueryHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.PluginReady,
 	}
@@ -686,7 +686,7 @@ type RecordDeleteHandler struct {
 	AccessModel   skydb.AccessModel `inject:"AccessModel"`
 	Authenticator router.Processor  `preprocessor:"authenticator"`
 	DBConn        router.Processor  `preprocessor:"dbconn"`
-	InjectUser    router.Processor  `preprocessor:"inject_user"`
+	InjectAuth    router.Processor  `preprocessor:"inject_auth"`
 	InjectDB      router.Processor  `preprocessor:"inject_db"`
 	RequireUser   router.Processor  `preprocessor:"require_user"`
 	PluginReady   router.Processor  `preprocessor:"plugin_ready"`
@@ -697,7 +697,7 @@ func (h *RecordDeleteHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.RequireUser,
 		h.PluginReady,

--- a/pkg/server/handler/relation.go
+++ b/pkg/server/handler/relation.go
@@ -18,8 +18,11 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/mitchellh/mapstructure"
 
+	"github.com/skygeario/skygear-server/pkg/server/asset"
 	"github.com/skygeario/skygear-server/pkg/server/router"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
+	"github.com/skygeario/skygear-server/pkg/server/skydb/recordutil"
+	"github.com/skygeario/skygear-server/pkg/server/skydb/skyconv"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )
 
@@ -85,7 +88,9 @@ func (payload *relationQueryPayload) Validate() skyerr.Error {
 //             "id": "1001",
 //             "type": "user",
 //             "data": {
-//                 "_id": "1001",
+//                 "_type": "record",
+//                 "_id": "user/1001",
+//                 "_access": null,
 //                 "username": "user1001",
 //                 "email": "user1001@skygear.io"
 //             }
@@ -94,7 +99,9 @@ func (payload *relationQueryPayload) Validate() skyerr.Error {
 //             "id": "1002",
 //             "type": "user",
 //             "data": {
+//                 "_type": "record",
 //                 "_id": "1002",
+//                 "_access": null,
 //                 "username": "user1002",
 //                 "email": "user1001@skygear.io"
 //             }
@@ -105,6 +112,7 @@ func (payload *relationQueryPayload) Validate() skyerr.Error {
 //     }
 // }
 type RelationQueryHandler struct {
+	AssetStore    asset.Store      `inject:"AssetStore"`
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"inject_auth"`
@@ -143,18 +151,17 @@ func (h *RelationQueryHandler) Handle(rpayload *router.Payload, response *router
 		})
 	resultList := make([]interface{}, 0, len(result))
 	for _, authinfo := range result {
-		data, err := fetchUserAuthData(rpayload.Database, rpayload.DBConn, authinfo.ID)
+		user, err := fetchUser(rpayload.Database, rpayload.DBConn, h.AssetStore, *rpayload.AuthInfo, authinfo.ID)
 		if err != nil {
 			response.Err = skyerr.MakeError(err)
 			return
 		}
 
-		data["_id"] = authinfo.ID
 		resultList = append(resultList, struct {
 			ID   string      `json:"id"`
 			Type string      `json:"type"`
 			Data interface{} `json:"data"`
-		}{authinfo.ID, "user", data})
+		}{authinfo.ID, "user", &user})
 	}
 	response.Result = resultList
 	count, countErr := rpayload.DBConn.QueryRelationCount(
@@ -215,7 +222,9 @@ func (payload *relationChangePayload) Validate() skyerr.Error {
 //             "id": "1001",
 //             "type": "user",
 //             "data": {
+//                 "_type": "record",
 //                 "_id": "1001",
+//                 "_access": null,
 //                 "username": "user1001",
 //                 "email": "user1001@skygear.io"
 //             }
@@ -232,6 +241,7 @@ func (payload *relationChangePayload) Validate() skyerr.Error {
 //     ]
 // }
 type RelationAddHandler struct {
+	AssetStore    asset.Store      `inject:"AssetStore"`
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"inject_auth"`
@@ -278,18 +288,17 @@ func (h *RelationAddHandler) Handle(rpayload *router.Payload, response *router.R
 				Data skyerr.Error `json:"data"`
 			}{target, "error", skyerr.NewResourceFetchFailureErr("user", target)})
 		} else {
-			data, err := fetchUserAuthData(rpayload.Database, rpayload.DBConn, target)
+			user, err := fetchUser(rpayload.Database, rpayload.DBConn, h.AssetStore, *rpayload.AuthInfo, target)
 			if err != nil {
 				response.Err = skyerr.MakeError(err)
 				return
 			}
 
-			data["_id"] = target
 			results = append(results, struct {
 				ID   string      `json:"id"`
 				Type string      `json:"type"`
 				Data interface{} `json:"data"`
-			}{target, "user", data})
+			}{target, "user", &user})
 		}
 	}
 	response.Result = results
@@ -363,23 +372,19 @@ func (h *RelationRemoveHandler) Handle(rpayload *router.Payload, response *route
 	response.Result = results
 }
 
-func fetchUserAuthData(db skydb.Database, conn skydb.Conn, userID string) (data map[string]interface{}, err error) {
-	data = map[string]interface{}{}
-
-	// TODO: return user record
+func fetchUser(db skydb.Database, conn skydb.Conn, assetStore asset.Store, info skydb.AuthInfo, userID string) (jsonUser skyconv.JSONRecord, err error) {
 	user := skydb.Record{}
 	if err = db.Get(skydb.NewRecordID("user", userID), &user); err != nil {
 		// TODO: handle auth without user in a better way
 		return
 	}
 
-	if username, _ := user.Data["username"].(string); username != "" {
-		data["username"] = username
+	filter, err := recordutil.NewRecordResultFilter(conn, assetStore, &info)
+	if err != nil {
+		return
 	}
 
-	if email, _ := user.Data["email"].(string); email != "" {
-		data["email"] = email
-	}
-
+	result := filter.JSONResult(&user)
+	jsonUser = *result
 	return
 }

--- a/pkg/server/handler/relation.go
+++ b/pkg/server/handler/relation.go
@@ -107,7 +107,7 @@ func (payload *relationQueryPayload) Validate() skyerr.Error {
 type RelationQueryHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
@@ -117,7 +117,7 @@ func (h *RelationQueryHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.PluginReady,
 	}
@@ -234,7 +234,7 @@ func (payload *relationChangePayload) Validate() skyerr.Error {
 type RelationAddHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
@@ -244,7 +244,7 @@ func (h *RelationAddHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.PluginReady,
 	}
@@ -311,7 +311,7 @@ func (h *RelationAddHandler) Handle(rpayload *router.Payload, response *router.R
 type RelationRemoveHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
@@ -321,7 +321,7 @@ func (h *RelationRemoveHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.PluginReady,
 	}

--- a/pkg/server/handler/relation.go
+++ b/pkg/server/handler/relation.go
@@ -19,9 +19,9 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/skygeario/skygear-server/pkg/server/asset"
+	"github.com/skygeario/skygear-server/pkg/server/recordutil"
 	"github.com/skygeario/skygear-server/pkg/server/router"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
-	"github.com/skygeario/skygear-server/pkg/server/skydb/recordutil"
 	"github.com/skygeario/skygear-server/pkg/server/skydb/skyconv"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )

--- a/pkg/server/handler/relation_test.go
+++ b/pkg/server/handler/relation_test.go
@@ -88,6 +88,10 @@ func (conn *testRelationConn) QueryRelationCount(user string, name string, direc
 	return count, nil
 }
 
+func (conn *testRelationConn) GetRecordFieldAccess() (skydb.FieldACL, error) {
+	return skydb.FieldACL{}, nil
+}
+
 func TestRelationHandler(t *testing.T) {
 	Convey("RelationAddHandler", t, func() {
 		conn := testRelationConn{}
@@ -116,6 +120,9 @@ func TestRelationHandler(t *testing.T) {
 			r := handlertest.NewSingleRouteRouter(&RelationAddHandler{}, func(p *router.Payload) {
 				p.DBConn = &conn
 				p.Database = db
+				p.AuthInfo = &skydb.AuthInfo{
+					ID: "user-1",
+				}
 			})
 
 			resp := r.POST(`{
@@ -133,7 +140,9 @@ func TestRelationHandler(t *testing.T) {
         "id": "some-friend",
         "type": "user",
         "data": {
-            "_id": "some-friend",
+            "_id": "user/some-friend",
+            "_type": "record",
+            "_access": null,
             "username": "testRelationConn"
         }
     }]
@@ -147,6 +156,9 @@ func TestRelationHandler(t *testing.T) {
 		Convey("query outward relation", func() {
 			r := handlertest.NewSingleRouteRouter(&RelationQueryHandler{}, func(p *router.Payload) {
 				p.DBConn = &conn
+				p.AuthInfo = &skydb.AuthInfo{
+					ID: "user-1",
+				}
 			})
 
 			resp := r.POST(`{
@@ -188,6 +200,9 @@ func TestRelationHandler(t *testing.T) {
 			r := handlertest.NewSingleRouteRouter(&RelationQueryHandler{}, func(p *router.Payload) {
 				p.DBConn = &conn
 				p.Database = db
+				p.AuthInfo = &skydb.AuthInfo{
+					ID: "user-1",
+				}
 			})
 
 			users := []skydb.AuthInfo{}
@@ -206,7 +221,9 @@ func TestRelationHandler(t *testing.T) {
         "id": "101",
         "type": "user",
         "data":{
-            "_id": "101",
+            "_id": "user/101",
+            "_type": "record",
+            "_access": null,
             "email": "user101@skygear.io",
             "username": "user101"
         }
@@ -220,6 +237,9 @@ func TestRelationHandler(t *testing.T) {
 		Convey("query relation with _follow", func() {
 			r := handlertest.NewSingleRouteRouter(&RelationQueryHandler{}, func(p *router.Payload) {
 				p.DBConn = &conn
+				p.AuthInfo = &skydb.AuthInfo{
+					ID: "user-1",
+				}
 			})
 
 			resp := r.POST(`{
@@ -261,6 +281,9 @@ func TestRelationHandler(t *testing.T) {
 			r := handlertest.NewSingleRouteRouter(&RelationQueryHandler{}, func(p *router.Payload) {
 				p.DBConn = &conn
 				p.Database = db
+				p.AuthInfo = &skydb.AuthInfo{
+					ID: "user-1",
+				}
 			})
 
 			user1 := skydb.AuthInfo{
@@ -286,7 +309,9 @@ func TestRelationHandler(t *testing.T) {
         "id": "101",
         "type": "user",
         "data":{
-            "_id": "101",
+            "_id": "user/101",
+            "_type": "record",
+            "_access": null,
             "email": "user101@skygear.io",
             "username": "user101"
         }
@@ -326,7 +351,9 @@ func TestRelationHandler(t *testing.T) {
         "id": "102",
         "type": "user",
         "data":{
-            "_id": "102",
+            "_id": "user/102",
+            "_type": "record",
+            "_access": null,
             "email": "user102@skygear.io",
             "username": "user102"
         }
@@ -340,6 +367,9 @@ func TestRelationHandler(t *testing.T) {
 		Convey("query relation with wrong direction", func() {
 			r := handlertest.NewSingleRouteRouter(&RelationQueryHandler{}, func(p *router.Payload) {
 				p.DBConn = &conn
+				p.AuthInfo = &skydb.AuthInfo{
+					ID: "user-1",
+				}
 			})
 
 			resp := r.POST(`{

--- a/pkg/server/handler/role.go
+++ b/pkg/server/handler/role.go
@@ -206,7 +206,7 @@ func (payload *roleBatchPayload) Validate() skyerr.Error {
 type RoleAssignHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -215,7 +215,7 @@ func (h *RoleAssignHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.PluginReady,
 	}
 }
@@ -282,7 +282,7 @@ func (h *RoleAssignHandler) Handle(rpayload *router.Payload, response *router.Re
 type RoleRevokeHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -291,7 +291,7 @@ func (h *RoleRevokeHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.PluginReady,
 	}
 }

--- a/pkg/server/handler/subscription.go
+++ b/pkg/server/handler/subscription.go
@@ -245,7 +245,7 @@ func (payload *subscriptionPayload) Validate() skyerr.Error {
 type SubscriptionFetchHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
 	RequireUser   router.Processor `preprocessor:"require_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
@@ -256,7 +256,7 @@ func (h *SubscriptionFetchHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.RequireUser,
 		h.PluginReady,
@@ -320,7 +320,7 @@ func (h *SubscriptionFetchHandler) Handle(rpayload *router.Payload, response *ro
 type SubscriptionFetchAllHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
 	RequireUser   router.Processor `preprocessor:"require_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
@@ -331,7 +331,7 @@ func (h *SubscriptionFetchAllHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.RequireUser,
 		h.PluginReady,
@@ -448,7 +448,7 @@ func (payload *subscriptionSavePayload) Validate() skyerr.Error {
 type SubscriptionSaveHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
 	RequireUser   router.Processor `preprocessor:"require_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
@@ -459,7 +459,7 @@ func (h *SubscriptionSaveHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.RequireUser,
 		h.PluginReady,
@@ -520,7 +520,7 @@ func (h *SubscriptionSaveHandler) Handle(rpayload *router.Payload, response *rou
 type SubscriptionDeleteHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
 	RequireUser   router.Processor `preprocessor:"require_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
@@ -531,7 +531,7 @@ func (h *SubscriptionDeleteHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.InjectDB,
 		h.RequireUser,
 		h.PluginReady,

--- a/pkg/server/plugin/handler.go
+++ b/pkg/server/plugin/handler.go
@@ -58,7 +58,7 @@ func (h *Handler) Setup() {
 		h.preprocessors = h.PreprocessorList.GetByNames(
 			"authenticator",
 			"dbconn",
-			"inject_user",
+			"inject_auth",
 			"require_user",
 			"plugin_ready",
 		)

--- a/pkg/server/plugin/lambda.go
+++ b/pkg/server/plugin/lambda.go
@@ -48,7 +48,7 @@ func (h *LambdaHandler) Setup() {
 		h.preprocessors = h.PreprocessorList.GetByNames(
 			"authenticator",
 			"dbconn",
-			"inject_user",
+			"inject_auth",
 			"require_user",
 			"plugin_ready",
 		)

--- a/pkg/server/preprocessor/preprocessor.go
+++ b/pkg/server/preprocessor/preprocessor.go
@@ -23,9 +23,9 @@ import (
 	"github.com/skygeario/skygear-server/pkg/server/asset"
 	"github.com/skygeario/skygear-server/pkg/server/logging"
 	"github.com/skygeario/skygear-server/pkg/server/plugin/hook"
+	"github.com/skygeario/skygear-server/pkg/server/recordutil"
 	"github.com/skygeario/skygear-server/pkg/server/router"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
-	"github.com/skygeario/skygear-server/pkg/server/skydb/recordutil"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )
 

--- a/pkg/server/preprocessor/preprocessor.go
+++ b/pkg/server/preprocessor/preprocessor.go
@@ -109,8 +109,8 @@ type InjectUserIfPresent struct {
 }
 
 func (p InjectUserIfPresent) Preprocess(payload *router.Payload, response *router.Response) int {
-	db := payload.Database
 	authInfo := payload.AuthInfo
+	db := payload.DBConn.PublicDB()
 
 	if authInfo == nil {
 		log.Debugln("injectUser: empty AuthInfo, skipping")
@@ -137,7 +137,7 @@ func (p InjectUserIfPresent) Preprocess(payload *router.Payload, response *route
 
 func (p InjectUserIfPresent) createUser(payload *router.Payload) (skydb.Record, error) {
 	authInfo := payload.AuthInfo
-	db := payload.Database
+	db := payload.DBConn.PublicDB()
 
 	userRecord := skydb.Record{
 		ID: skydb.NewRecordID(db.UserRecordType(), authInfo.ID),

--- a/pkg/server/preprocessor/preprocessor.go
+++ b/pkg/server/preprocessor/preprocessor.go
@@ -28,7 +28,7 @@ import (
 
 var log = logging.LoggerEntry("preprocessor")
 
-type InjectUserIfPresent struct {
+type InjectAuthIfPresent struct {
 }
 
 func isTokenStillValid(token router.AccessToken, authInfo skydb.AuthInfo) bool {
@@ -49,7 +49,7 @@ func isTokenStillValid(token router.AccessToken, authInfo skydb.AuthInfo) bool {
 	return token.IssuedAt().After(tokenValidSince.Add(-1 * time.Second))
 }
 
-func (p InjectUserIfPresent) Preprocess(payload *router.Payload, response *router.Response) int {
+func (p InjectAuthIfPresent) Preprocess(payload *router.Payload, response *router.Response) int {
 	// TODO: Inject both AuthInfo and user Record
 	if payload.AuthInfoID == "" {
 		if !payload.HasMasterKey() {

--- a/pkg/server/preprocessor/preprocessor_test.go
+++ b/pkg/server/preprocessor/preprocessor_test.go
@@ -209,9 +209,9 @@ func (t injectUserPreprocessorAccessToken) IssuedAt() time.Time {
 	return t.issuedAt
 }
 
-func TestInjectUserProcessor(t *testing.T) {
-	Convey("InjectUser", t, func() {
-		pp := InjectUserIfPresent{}
+func TestInjectAuthProcessor(t *testing.T) {
+	Convey("InjectAuth", t, func() {
+		pp := InjectAuthIfPresent{}
 		conn := skydbtest.NewMapConn()
 
 		withoutTokenValidSince := skydb.AuthInfo{

--- a/pkg/server/router/model.go
+++ b/pkg/server/router/model.go
@@ -117,6 +117,8 @@ type Payload struct {
 
 	DBConn   skydb.Conn
 	Database skydb.Database
+
+	User *skydb.Record
 }
 
 // RouteAction must exist for every request

--- a/pkg/server/skydb/authinfo.go
+++ b/pkg/server/skydb/authinfo.go
@@ -102,7 +102,7 @@ func (a AuthData) IsValid() bool {
 func (a AuthData) IsEmpty() bool {
 	emptyCount := 0
 	for k := range a {
-		if a.IsFieldEmpty(k) {
+		if a.isFieldEmpty(k) {
 			emptyCount = emptyCount + 1
 		}
 	}
@@ -110,7 +110,7 @@ func (a AuthData) IsEmpty() bool {
 	return len(a) == emptyCount
 }
 
-func (a AuthData) IsFieldEmpty(key string) bool {
+func (a AuthData) isFieldEmpty(key string) bool {
 	return a[key] == nil
 }
 

--- a/pkg/server/skydb/authinfo.go
+++ b/pkg/server/skydb/authinfo.go
@@ -100,14 +100,17 @@ func (a AuthData) IsValid() bool {
 // 1. no entries or
 // 2. all values are null
 func (a AuthData) IsEmpty() bool {
-	emptyCount := 0
+	if len(a) == 0 {
+		return true
+	}
+
 	for k := range a {
-		if a.isFieldEmpty(k) {
-			emptyCount = emptyCount + 1
+		if !a.isFieldEmpty(k) {
+			return false
 		}
 	}
 
-	return len(a) == emptyCount
+	return true
 }
 
 func (a AuthData) isFieldEmpty(key string) bool {

--- a/pkg/server/skydb/authinfo_test.go
+++ b/pkg/server/skydb/authinfo_test.go
@@ -59,6 +59,45 @@ func TestNewProviderInfoAuthInfo(t *testing.T) {
 	})
 }
 
+func TestAuthData(t *testing.T) {
+	Convey("Test AuthData", t, func() {
+		Convey("valid AuthData", func() {
+			So(AuthData{
+				"username": "johndoe",
+			}.IsValid(), ShouldBeTrue)
+
+			So(AuthData{
+				"email": "johndoe@example.com",
+			}.IsValid(), ShouldBeTrue)
+
+			So(AuthData{
+				"username": "johndoe",
+				"email":    "johndoe@example.com",
+			}.IsValid(), ShouldBeTrue)
+		})
+
+		Convey("invalid AuthData", func() {
+			So(AuthData{}.IsValid(), ShouldBeFalse)
+			So(AuthData{
+				"iamyourfather": "johndoe",
+			}.IsValid(), ShouldBeFalse)
+			So(AuthData{
+				"username": nil,
+			}.IsValid(), ShouldBeFalse)
+		})
+
+		Convey("empty AuthData", func() {
+			So(AuthData{}.IsEmpty(), ShouldBeTrue)
+			So(AuthData{
+				"username": nil,
+			}.IsEmpty(), ShouldBeTrue)
+			So(AuthData{
+				"iamyourfather": "johndoe",
+			}.IsEmpty(), ShouldBeFalse)
+		})
+	})
+}
+
 func TestSetPassword(t *testing.T) {
 	info := AuthInfo{}
 	info.SetPassword("secret")

--- a/pkg/server/skydb/skydbtest/skydbmockutil.go
+++ b/pkg/server/skydb/skydbtest/skydbmockutil.go
@@ -1,0 +1,45 @@
+// Copyright 2015-present Oursky Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skydbtest
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/skygeario/skygear-server/pkg/server/skydb"
+	"github.com/skygeario/skygear-server/pkg/server/skydb/mock_skydb"
+)
+
+func ExpectDBSaveUser(db *mock_skydb.MockTxDatabase, extendedSchema skydb.RecordSchema, assertSavedUserRecord interface{}) {
+	db.EXPECT().UserRecordType().Return("user").AnyTimes()
+	db.EXPECT().ID().Return("_public").AnyTimes()
+
+	// no record found
+	db.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return(skydb.ErrRecordNotFound).
+		AnyTimes()
+
+	// extend Schema
+	db.EXPECT().GetSchema("user").Return(skydb.RecordSchema{}, nil).AnyTimes()
+	db.EXPECT().Extend("user", extendedSchema).Return(len(extendedSchema) > 0, nil).AnyTimes()
+
+	// if len(extendedSchema) > 0 {
+	// }
+
+	db.EXPECT().
+		Save(gomock.Any()).
+		Do(assertSavedUserRecord).
+		Return(nil).
+		AnyTimes()
+}

--- a/pkg/server/skydb/skydbtest/skydbtest.go
+++ b/pkg/server/skydb/skydbtest/skydbtest.go
@@ -26,6 +26,7 @@ import (
 type MapConn struct {
 	UserMap                map[string]skydb.AuthInfo
 	AssetMap               map[string]skydb.Asset
+	InternalPublicDB       skydb.Database
 	usernameMap            map[string]skydb.AuthInfo
 	emailMap               map[string]skydb.AuthInfo
 	recordAccessMap        map[string]skydb.RecordACL
@@ -238,7 +239,7 @@ func (conn *MapConn) DeleteEmptyDevicesByTime(t time.Time) error {
 
 // PublicDB is not implemented.
 func (conn *MapConn) PublicDB() skydb.Database {
-	panic("not implemented")
+	return conn.InternalPublicDB
 }
 
 // PrivateDB is not implemented.

--- a/pkg/server/skyerr/errorcode_string.go
+++ b/pkg/server/skyerr/errorcode_string.go
@@ -6,12 +6,12 @@ import "fmt"
 
 const (
 	_ErrorCode_name_0 = "NotAuthenticatedPermissionDeniedAccessKeyNotAcceptedAccessTokenNotAcceptedInvalidCredentialsInvalidSignatureBadRequestInvalidArgumentDuplicatedResourceNotFoundNotSupportedNotImplementedConstraintViolatedIncompatibleSchemaAtomicOperationFailurePartialOperationFailureUndefinedOperationPluginUnavailablePluginTimeoutRecordQueryInvalidPluginInitializingResponseTimeoutDeniedArgumentRecordQueryDenied"
-	_ErrorCode_name_1 = "UnexpectedErrorUnexpectedAuthInfoNotFoundUnexpectedUnableToOpenDatabaseUnexpectedPushNotificationNotConfiguredInternalQueryInvalid"
+	_ErrorCode_name_1 = "UnexpectedErrorUnexpectedAuthInfoNotFoundUnexpectedUnableToOpenDatabaseUnexpectedPushNotificationNotConfiguredInternalQueryInvalidUnexpectedUserNotFound"
 )
 
 var (
 	_ErrorCode_index_0 = [...]uint16{0, 16, 32, 52, 74, 92, 108, 118, 133, 143, 159, 171, 185, 203, 221, 243, 266, 284, 301, 314, 332, 350, 365, 379, 396}
-	_ErrorCode_index_1 = [...]uint8{0, 15, 41, 71, 110, 130}
+	_ErrorCode_index_1 = [...]uint8{0, 15, 41, 71, 110, 130, 152}
 )
 
 func (i ErrorCode) String() string {
@@ -19,7 +19,7 @@ func (i ErrorCode) String() string {
 	case 101 <= i && i <= 124:
 		i -= 101
 		return _ErrorCode_name_0[_ErrorCode_index_0[i]:_ErrorCode_index_0[i+1]]
-	case 10000 <= i && i <= 10004:
+	case 10000 <= i && i <= 10005:
 		i -= 10000
 		return _ErrorCode_name_1[_ErrorCode_index_1[i]:_ErrorCode_index_1[i+1]]
 	default:

--- a/pkg/server/skyerr/skyerr.go
+++ b/pkg/server/skyerr/skyerr.go
@@ -252,7 +252,7 @@ func NewResourceFetchFailureErr(kind string, id interface{}) Error {
 	return NewError(UnexpectedError, fmt.Sprintf("failed to fetch %v id = %v", kind, id))
 }
 
-func newResourceSaveFailureErr(kind string, id interface{}) Error {
+func NewResourceSaveFailureErr(kind string, id interface{}) Error {
 	var message string
 	if id != nil {
 		message = fmt.Sprintf("failed to save %v id = %v", kind, id)
@@ -270,7 +270,7 @@ func NewResourceSaveFailureErrWithStringID(kind string, id string) Error {
 	if id != "" {
 		iID = id
 	}
-	return newResourceSaveFailureErr(kind, iID)
+	return NewResourceSaveFailureErr(kind, iID)
 }
 
 func newResourceDeleteFailureErr(kind string, id interface{}) Error {

--- a/pkg/server/skyerr/skyerr.go
+++ b/pkg/server/skyerr/skyerr.go
@@ -158,6 +158,7 @@ const (
 	UnexpectedUnableToOpenDatabase
 	UnexpectedPushNotificationNotConfigured
 	InternalQueryInvalid
+	UnexpectedUserNotFound
 
 	// Error codes for unexpected error condition should be placed
 	// above this line.


### PR DESCRIPTION
connect #393
need #421

- Update signup and login request to accept `auth_data`
- Update signup, login, add relation and query relation response to return user record
- Treat empty string value in `auth_data` as valid value, so it would not be purged
  - `auth_data` is no longer restricted to string, if empty string is purged, then `0` and `false` would also be purged, which does not make sense
- Add InjectUserIfPresent preprocessor

Note:
`AUTH_RECORD_KEYS` is NOT implemented yet, the current implementation is equal to `AUTH_RECORD_KEYS=username,email`. Most likely, the next, and hopefully the last for the feature, PR would finish that.