### PR TITLE
Fix unable to build working docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
-go: 1.8.1
+go: 1.8.3
 
 addons:
   postgresql: "9.5"
@@ -68,21 +68,21 @@ deploy:
     on:
       repo: SkygearIO/skygear-server
       tags: true
-      go: 1.8.1
+      go: 1.8.3
   - provider: script
     script: ./scripts/deploy-docker-hub.sh
     skip_cleanup: true
     on:
       repo: SkygearIO/skygear-server
       all_branches: true
-      go: 1.8.1
+      go: 1.8.3
   - provider: script
     script: ./scripts/deploy-quay-io.sh
     skip_cleanup: true
     on:
       repo: SkygearIO/skygear-server
       all_branches: true
-      go: 1.8.1
+      go: 1.8.3
 
 notifications:
   slack:

--- a/scripts/docker-images/godev/Dockerfile
+++ b/scripts/docker-images/godev/Dockerfile
@@ -1,11 +1,8 @@
-FROM golang:1.8.1
+FROM golang:1.8.3-stretch
 
 RUN \
     apt-get update && \
-    apt-get install --no-install-recommends -y libtool-bin automake pkg-config libsodium-dev libzmq3-dev && \
-    git clone --branch v4.0.2 --depth 1 git://github.com/zeromq/czmq.git && \
-    ( cd czmq; ./autogen.sh; ./configure; make check; make install; ldconfig ) && \
-    rm -rf czmq && \
+    apt-get install --no-install-recommends -y libtool-bin automake pkg-config libsodium-dev libzmq3-dev libczmq-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl https://glide.sh/get | sh && \


### PR DESCRIPTION
This is because the libzmq libraries installed in debian jessie
is too old for czmq 4.0.2. Upgrading to debian stretch solved the
problem.

The golang version is also upgraded to go1.8.3.