### PR TITLE
Use only annotated tags for version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DIST_DIR = ./dist/
 DIST := skygear-server
-VERSION := $(shell git describe --always --tags)
+VERSION := $(shell git describe --always)
 GO_BUILD_LDFLAGS := -ldflags "-X github.com/skygeario/skygear-server/pkg/server/skyversion.version=$(VERSION)"
 GO_TEST_TIMEOUT := 1m30s
 OSARCHS := linux/amd64 linux/386 linux/arm windows/amd64 windows/386 darwin/amd64

--- a/scripts/docker-images/release/Makefile
+++ b/scripts/docker-images/release/Makefile
@@ -1,6 +1,6 @@
 GIT_SHA := $(shell git rev-parse HEAD)
 GIT_SHORT_SHA := $(shell git rev-parse --short HEAD)
-VERSION := $(shell git describe --always --tags)
+VERSION := $(shell git describe --always)
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 DOCKER_REGISTRY := 


### PR DESCRIPTION
This is because `latest` is also used as tag for release purposes and
`--tags` option makes `latest` appears in version string.