### PR TITLE
Fix test failure after refactoring

### DIFF
--- a/pkg/server/preprocessor/preprocessor_test.go
+++ b/pkg/server/preprocessor/preprocessor_test.go
@@ -318,10 +318,11 @@ func TestInjectAuthProcessor(t *testing.T) {
 		})
 
 		Convey("should check password expiry", func() {
-			realTimeNow := timeNow
-			timeNow = func() time.Time { return time.Date(2017, 12, 2, 0, 0, 0, 0, time.UTC) }
+			realTimeNow := skydb.GetTimeNowForTestingOnlyPleaseDoNotUseThis()
+			mockedTimeNow := func() time.Time { return time.Date(2017, 12, 2, 0, 0, 0, 0, time.UTC) }
+			skydb.SetTimeNowForTestingOnlyPleaseDoNotUseThis(mockedTimeNow)
 			defer func() {
-				timeNow = realTimeNow
+				skydb.SetTimeNowForTestingOnlyPleaseDoNotUseThis(realTimeNow)
 			}()
 			ppWithPasswordExpiryDays := InjectAuthIfPresent{
 				PwExpiryDays: 30,

--- a/pkg/server/skydb/skydb.go
+++ b/pkg/server/skydb/skydb.go
@@ -21,3 +21,14 @@ import (
 
 var log = logging.LoggerEntry("skydb")
 var timeNow = func() time.Time { return time.Now().UTC() }
+
+// SetTimeNowForTestingOnlyPleaseDoNotUseThis sets timeNow
+// for testing purpose only.
+func SetTimeNowForTestingOnlyPleaseDoNotUseThis(f func() time.Time) {
+	timeNow = f
+}
+
+// GetTimeNowForTestingOnlyPleaseDoNotUseThis returns timeNow
+func GetTimeNowForTestingOnlyPleaseDoNotUseThis() func() time.Time {
+	return timeNow
+}


### PR DESCRIPTION
I wonder if I can avoid the getter and setter. I took a look at `reflect` but it does not allow me to set a package var reflectively.