### PR TITLE
Fix async hook not executed

### DIFF
--- a/pkg/server/router/model.go
+++ b/pkg/server/router/model.go
@@ -24,6 +24,13 @@ import (
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )
 
+// TODO(cheungpat): We should put these values into a struct that is stored
+// in context.Context, rather than storing individual values. Before this
+// happens, this list should be keep in sync with the following locations:
+// - pkg/server/plugin/hook.go
+// - pkg/server/plugin/transport.go
+
+// ContextKey is the name of the values that are saved to context.Context.
 type ContextKey string
 
 var UserIDContextKey ContextKey = "UserID"


### PR DESCRIPTION
This happens because the hook execution is bound to the client request
context, which could finish sooner than the execution of an async
hook. This is fixed by copying the request context into a new background
context, which has a separate timeout.

connects #553