### PR TITLE
Update logic for user checking in preprocessors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,3 +149,6 @@ CUSTOM_TOKEN_SECRET="ssosecret"
 #
 # BUG_TRANSPORT=zmq
 # BUG_PATH=tcp://skygear:5555
+
+# Verification
+# VERIFY_REQUIRED=false

--- a/main.go
+++ b/main.go
@@ -188,7 +188,18 @@ func main() {
 		PwExpiryDays: config.UserAudit.PwExpiryDays,
 		Required:     true,
 	}
-	preprocessorRegistry["inject_user"] = &pp.InjectUserIfPresent{}
+	preprocessorRegistry["require_user"] = &pp.InjectUser{
+		Required:          true,
+		CheckVerification: config.Verification.Required,
+	}
+	if config.Verification.Required {
+		preprocessorRegistry["check_user"] = &pp.InjectUser{
+			Required:          false,
+			CheckVerification: true,
+		}
+	} else {
+		preprocessorRegistry["check_user"] = &pp.Null{}
+	}
 	preprocessorRegistry["require_admin"] = &pp.RequireAdminOrMasterKey{}
 	preprocessorRegistry["require_master_key"] = &pp.RequireMasterKey{}
 	preprocessorRegistry["inject_db"] = &pp.InjectDatabase{}

--- a/main.go
+++ b/main.go
@@ -181,11 +181,14 @@ func main() {
 		ClientKey:     config.App.APIKey,
 		MasterKey:     config.App.MasterKey,
 	}
-	preprocessorRegistry["inject_auth"] = &pp.InjectAuthIfPresent{
+	preprocessorRegistry["inject_auth"] = &pp.InjectAuth{
 		PwExpiryDays: config.UserAudit.PwExpiryDays,
 	}
+	preprocessorRegistry["require_auth"] = &pp.InjectAuth{
+		PwExpiryDays: config.UserAudit.PwExpiryDays,
+		Required:     true,
+	}
 	preprocessorRegistry["inject_user"] = &pp.InjectUserIfPresent{}
-	preprocessorRegistry["require_auth"] = &pp.RequireAuth{}
 	preprocessorRegistry["require_admin"] = &pp.RequireAdminOrMasterKey{}
 	preprocessorRegistry["require_master_key"] = &pp.RequireMasterKey{}
 	preprocessorRegistry["inject_db"] = &pp.InjectDatabase{}

--- a/pkg/server/handler/auth.go
+++ b/pkg/server/handler/auth.go
@@ -629,7 +629,7 @@ type ChangePasswordHandler struct {
 	Authenticator   router.Processor       `preprocessor:"authenticator"`
 	DBConn          router.Processor       `preprocessor:"dbconn"`
 	InjectAuth      router.Processor       `preprocessor:"require_auth"`
-	InjectUser      router.Processor       `preprocessor:"inject_user"`
+	InjectUser      router.Processor       `preprocessor:"require_user"`
 	PluginReady     router.Processor       `preprocessor:"plugin_ready"`
 	preprocessors   []router.Processor
 }

--- a/pkg/server/handler/auth.go
+++ b/pkg/server/handler/auth.go
@@ -628,9 +628,8 @@ type ChangePasswordHandler struct {
 	PwHousekeeper   *audit.PwHousekeeper   `inject:"PwHousekeeper"`
 	Authenticator   router.Processor       `preprocessor:"authenticator"`
 	DBConn          router.Processor       `preprocessor:"dbconn"`
-	InjectAuth      router.Processor       `preprocessor:"inject_auth"`
+	InjectAuth      router.Processor       `preprocessor:"require_auth"`
 	InjectUser      router.Processor       `preprocessor:"inject_user"`
-	RequireAuth     router.Processor       `preprocessor:"require_auth"`
 	PluginReady     router.Processor       `preprocessor:"plugin_ready"`
 	preprocessors   []router.Processor
 }
@@ -641,7 +640,6 @@ func (h *ChangePasswordHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectUser,
-		h.RequireAuth,
 		h.PluginReady,
 	}
 }

--- a/pkg/server/handler/auth_disable_set.go
+++ b/pkg/server/handler/auth_disable_set.go
@@ -92,7 +92,6 @@ type SetDisableUserHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"inject_auth"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
 	RequireAdmin  router.Processor `preprocessor:"require_admin"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
@@ -103,7 +102,6 @@ func (h *SetDisableUserHandler) Setup() {
 		h.Authenticator,
 		h.DBConn,
 		h.InjectAuth,
-		h.InjectUser,
 		h.RequireAdmin,
 		h.PluginReady,
 	}

--- a/pkg/server/handler/device.go
+++ b/pkg/server/handler/device.go
@@ -108,6 +108,7 @@ type DeviceRegisterHandler struct {
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
+	CheckUser     router.Processor `preprocessor:"check_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -118,6 +119,7 @@ func (h *DeviceRegisterHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }
@@ -203,6 +205,7 @@ type DeviceUnregisterHandler struct {
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
+	CheckUser     router.Processor `preprocessor:"check_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -213,6 +216,7 @@ func (h *DeviceUnregisterHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }

--- a/pkg/server/handler/device.go
+++ b/pkg/server/handler/device.go
@@ -106,9 +106,8 @@ type DeviceReigsterResult struct {
 type DeviceRegisterHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectAuth    router.Processor `preprocessor:"inject_auth"`
+	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
-	RequireAuth   router.Processor `preprocessor:"require_auth"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -119,7 +118,6 @@ func (h *DeviceRegisterHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
-		h.RequireAuth,
 		h.PluginReady,
 	}
 }
@@ -203,9 +201,8 @@ func (h *DeviceRegisterHandler) Handle(rpayload *router.Payload, response *route
 type DeviceUnregisterHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectAuth    router.Processor `preprocessor:"inject_auth"`
+	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
-	RequireAuth   router.Processor `preprocessor:"require_auth"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -216,7 +213,6 @@ func (h *DeviceUnregisterHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
-		h.RequireAuth,
 		h.PluginReady,
 	}
 }

--- a/pkg/server/handler/me.go
+++ b/pkg/server/handler/me.go
@@ -28,8 +28,7 @@ type MeHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectUser    router.Processor `preprocessor:"inject_user"`
-	InjectAuth    router.Processor `preprocessor:"inject_auth"`
-	RequireAuth   router.Processor `preprocessor:"require_auth"`
+	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -41,7 +40,6 @@ func (h *MeHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectUser,
-		h.RequireAuth,
 		h.PluginReady,
 	}
 }

--- a/pkg/server/handler/me.go
+++ b/pkg/server/handler/me.go
@@ -28,7 +28,7 @@ type MeHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"require_auth"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectUser    router.Processor `preprocessor:"require_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }

--- a/pkg/server/handler/me.go
+++ b/pkg/server/handler/me.go
@@ -27,8 +27,8 @@ type MeHandler struct {
 	AssetStore    asset.Store      `inject:"AssetStore"`
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
 	InjectAuth    router.Processor `preprocessor:"require_auth"`
+	InjectUser    router.Processor `preprocessor:"inject_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }

--- a/pkg/server/handler/record.go
+++ b/pkg/server/handler/record.go
@@ -246,9 +246,8 @@ type RecordSaveHandler struct {
 	AuthRecordKeys [][]string         `inject:"AuthRecordKeys"`
 	Authenticator  router.Processor   `preprocessor:"authenticator"`
 	DBConn         router.Processor   `preprocessor:"dbconn"`
-	InjectAuth     router.Processor   `preprocessor:"inject_auth"`
+	InjectAuth     router.Processor   `preprocessor:"require_auth"`
 	InjectDB       router.Processor   `preprocessor:"inject_db"`
-	RequireAuth    router.Processor   `preprocessor:"require_auth"`
 	PluginReady    router.Processor   `preprocessor:"plugin_ready"`
 	preprocessors  []router.Processor
 }
@@ -259,7 +258,6 @@ func (h *RecordSaveHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
-		h.RequireAuth,
 		h.PluginReady,
 	}
 }
@@ -720,9 +718,8 @@ type RecordDeleteHandler struct {
 	AccessModel   skydb.AccessModel `inject:"AccessModel"`
 	Authenticator router.Processor  `preprocessor:"authenticator"`
 	DBConn        router.Processor  `preprocessor:"dbconn"`
-	InjectAuth    router.Processor  `preprocessor:"inject_auth"`
+	InjectAuth    router.Processor  `preprocessor:"require_auth"`
 	InjectDB      router.Processor  `preprocessor:"inject_db"`
-	RequireAuth   router.Processor  `preprocessor:"require_auth"`
 	PluginReady   router.Processor  `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -733,7 +730,6 @@ func (h *RecordDeleteHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
-		h.RequireAuth,
 		h.PluginReady,
 	}
 }

--- a/pkg/server/handler/record.go
+++ b/pkg/server/handler/record.go
@@ -248,6 +248,7 @@ type RecordSaveHandler struct {
 	DBConn         router.Processor   `preprocessor:"dbconn"`
 	InjectAuth     router.Processor   `preprocessor:"require_auth"`
 	InjectDB       router.Processor   `preprocessor:"inject_db"`
+	CheckUser      router.Processor   `preprocessor:"check_user"`
 	PluginReady    router.Processor   `preprocessor:"plugin_ready"`
 	preprocessors  []router.Processor
 }
@@ -258,6 +259,7 @@ func (h *RecordSaveHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }
@@ -441,6 +443,7 @@ type RecordFetchHandler struct {
 	DBConn        router.Processor  `preprocessor:"dbconn"`
 	InjectAuth    router.Processor  `preprocessor:"inject_auth"`
 	InjectDB      router.Processor  `preprocessor:"inject_db"`
+	CheckUser     router.Processor  `preprocessor:"check_user"`
 	PluginReady   router.Processor  `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -451,6 +454,7 @@ func (h *RecordFetchHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }
@@ -540,6 +544,7 @@ type RecordQueryHandler struct {
 	DBConn        router.Processor  `preprocessor:"dbconn"`
 	InjectAuth    router.Processor  `preprocessor:"inject_auth"`
 	InjectDB      router.Processor  `preprocessor:"inject_db"`
+	CheckUser     router.Processor  `preprocessor:"check_user"`
 	PluginReady   router.Processor  `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -550,6 +555,7 @@ func (h *RecordQueryHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }
@@ -720,6 +726,7 @@ type RecordDeleteHandler struct {
 	DBConn        router.Processor  `preprocessor:"dbconn"`
 	InjectAuth    router.Processor  `preprocessor:"require_auth"`
 	InjectDB      router.Processor  `preprocessor:"inject_db"`
+	CheckUser     router.Processor  `preprocessor:"check_user"`
 	PluginReady   router.Processor  `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -730,6 +737,7 @@ func (h *RecordDeleteHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }

--- a/pkg/server/handler/relation.go
+++ b/pkg/server/handler/relation.go
@@ -117,6 +117,7 @@ type RelationQueryHandler struct {
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
+	CheckUser     router.Processor `preprocessor:"check_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -127,6 +128,7 @@ func (h *RelationQueryHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }
@@ -253,6 +255,7 @@ type RelationAddHandler struct {
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
+	CheckUser     router.Processor `preprocessor:"check_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -263,6 +266,7 @@ func (h *RelationAddHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }
@@ -336,6 +340,7 @@ type RelationRemoveHandler struct {
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
+	CheckUser     router.Processor `preprocessor:"check_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -346,6 +351,7 @@ func (h *RelationRemoveHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }

--- a/pkg/server/handler/schema.go
+++ b/pkg/server/handler/schema.go
@@ -644,7 +644,7 @@ EOF
 type SchemaFieldAccessGetHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	RequireAdmin  router.Processor `preprocessor:"require_admin"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
@@ -654,7 +654,7 @@ func (h *SchemaFieldAccessGetHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.RequireAdmin,
 		h.PluginReady,
 	}
@@ -732,7 +732,7 @@ EOF
 type SchemaFieldAccessUpdateHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectUser    router.Processor `preprocessor:"inject_user"`
+	InjectAuth    router.Processor `preprocessor:"inject_auth"`
 	RequireAdmin  router.Processor `preprocessor:"require_admin"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
@@ -742,7 +742,7 @@ func (h *SchemaFieldAccessUpdateHandler) Setup() {
 	h.preprocessors = []router.Processor{
 		h.Authenticator,
 		h.DBConn,
-		h.InjectUser,
+		h.InjectAuth,
 		h.RequireAdmin,
 		h.PluginReady,
 	}

--- a/pkg/server/handler/subscription.go
+++ b/pkg/server/handler/subscription.go
@@ -245,9 +245,8 @@ func (payload *subscriptionPayload) Validate() skyerr.Error {
 type SubscriptionFetchHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectAuth    router.Processor `preprocessor:"inject_auth"`
+	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
-	RequireAuth   router.Processor `preprocessor:"require_auth"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -258,7 +257,6 @@ func (h *SubscriptionFetchHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
-		h.RequireAuth,
 		h.PluginReady,
 	}
 }
@@ -320,9 +318,8 @@ func (h *SubscriptionFetchHandler) Handle(rpayload *router.Payload, response *ro
 type SubscriptionFetchAllHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectAuth    router.Processor `preprocessor:"inject_auth"`
+	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
-	RequireAuth   router.Processor `preprocessor:"require_auth"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -333,7 +330,6 @@ func (h *SubscriptionFetchAllHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
-		h.RequireAuth,
 		h.PluginReady,
 	}
 }
@@ -448,9 +444,8 @@ func (payload *subscriptionSavePayload) Validate() skyerr.Error {
 type SubscriptionSaveHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectAuth    router.Processor `preprocessor:"inject_auth"`
+	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
-	RequireAuth   router.Processor `preprocessor:"require_auth"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -461,7 +456,6 @@ func (h *SubscriptionSaveHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
-		h.RequireAuth,
 		h.PluginReady,
 	}
 }
@@ -520,9 +514,8 @@ func (h *SubscriptionSaveHandler) Handle(rpayload *router.Payload, response *rou
 type SubscriptionDeleteHandler struct {
 	Authenticator router.Processor `preprocessor:"authenticator"`
 	DBConn        router.Processor `preprocessor:"dbconn"`
-	InjectAuth    router.Processor `preprocessor:"inject_auth"`
+	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
-	RequireAuth   router.Processor `preprocessor:"require_auth"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -533,7 +526,6 @@ func (h *SubscriptionDeleteHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
-		h.RequireAuth,
 		h.PluginReady,
 	}
 }

--- a/pkg/server/handler/subscription.go
+++ b/pkg/server/handler/subscription.go
@@ -247,6 +247,7 @@ type SubscriptionFetchHandler struct {
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
+	CheckUser     router.Processor `preprocessor:"check_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -257,6 +258,7 @@ func (h *SubscriptionFetchHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }
@@ -320,6 +322,7 @@ type SubscriptionFetchAllHandler struct {
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
+	CheckUser     router.Processor `preprocessor:"check_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -330,6 +333,7 @@ func (h *SubscriptionFetchAllHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }
@@ -446,6 +450,7 @@ type SubscriptionSaveHandler struct {
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
+	CheckUser     router.Processor `preprocessor:"check_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -456,6 +461,7 @@ func (h *SubscriptionSaveHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }
@@ -516,6 +522,7 @@ type SubscriptionDeleteHandler struct {
 	DBConn        router.Processor `preprocessor:"dbconn"`
 	InjectAuth    router.Processor `preprocessor:"require_auth"`
 	InjectDB      router.Processor `preprocessor:"inject_db"`
+	CheckUser     router.Processor `preprocessor:"check_user"`
 	PluginReady   router.Processor `preprocessor:"plugin_ready"`
 	preprocessors []router.Processor
 }
@@ -526,6 +533,7 @@ func (h *SubscriptionDeleteHandler) Setup() {
 		h.DBConn,
 		h.InjectAuth,
 		h.InjectDB,
+		h.CheckUser,
 		h.PluginReady,
 	}
 }

--- a/pkg/server/plugin/handler.go
+++ b/pkg/server/plugin/handler.go
@@ -59,6 +59,7 @@ func (h *Handler) Setup() {
 			"authenticator",
 			"dbconn",
 			"require_auth",
+			"check_user",
 			"plugin_ready",
 		)
 	} else if h.AccessKeyRequired {

--- a/pkg/server/plugin/handler.go
+++ b/pkg/server/plugin/handler.go
@@ -58,7 +58,6 @@ func (h *Handler) Setup() {
 		h.preprocessors = h.PreprocessorList.GetByNames(
 			"authenticator",
 			"dbconn",
-			"inject_auth",
 			"require_auth",
 			"plugin_ready",
 		)

--- a/pkg/server/plugin/lambda.go
+++ b/pkg/server/plugin/lambda.go
@@ -48,7 +48,6 @@ func (h *LambdaHandler) Setup() {
 		h.preprocessors = h.PreprocessorList.GetByNames(
 			"authenticator",
 			"dbconn",
-			"inject_auth",
 			"require_auth",
 			"plugin_ready",
 		)

--- a/pkg/server/plugin/lambda.go
+++ b/pkg/server/plugin/lambda.go
@@ -49,6 +49,7 @@ func (h *LambdaHandler) Setup() {
 			"authenticator",
 			"dbconn",
 			"require_auth",
+			"check_user",
 			"plugin_ready",
 		)
 	} else if h.AccessKeyRequired {

--- a/pkg/server/preprocessor/preprocessor.go
+++ b/pkg/server/preprocessor/preprocessor.go
@@ -90,6 +90,7 @@ func (p InjectAuth) Preprocess(payload *router.Payload, response *router.Respons
 		}
 
 		if status == http.StatusInternalServerError {
+			response.Err = lastError
 			return
 		}
 

--- a/pkg/server/preprocessor/preprocessor_test.go
+++ b/pkg/server/preprocessor/preprocessor_test.go
@@ -215,7 +215,9 @@ func (t injectUserPreprocessorAccessToken) IssuedAt() time.Time {
 
 func TestInjectAuthProcessor(t *testing.T) {
 	Convey("InjectAuth", t, func() {
-		pp := InjectAuthIfPresent{}
+		pp := InjectAuth{
+			Required: true,
+		}
 		conn := skydbtest.NewMapConn()
 
 		withoutTokenValidSince := skydb.AuthInfo{
@@ -322,8 +324,9 @@ func TestInjectAuthProcessor(t *testing.T) {
 			timeNow = func() time.Time { return time.Date(2017, 12, 2, 0, 0, 0, 0, time.UTC) }
 			restore := skydb.MockTimeNowForTestingOnly(timeNow)
 			defer restore()
-			ppWithPasswordExpiryDays := InjectAuthIfPresent{
+			ppWithPasswordExpiryDays := InjectAuth{
 				PwExpiryDays: 30,
+				Required:     true,
 			}
 
 			payload1 := router.Payload{

--- a/pkg/server/preprocessor/preprocessor_test.go
+++ b/pkg/server/preprocessor/preprocessor_test.go
@@ -383,10 +383,18 @@ func TestInjectAuthProcessor(t *testing.T) {
 				AuthInfoID: "some-uuid",
 			}
 			resp := router.Response{}
-			So(pp.Preprocess(&payload, &resp), ShouldEqual, http.StatusForbidden)
 
-			So(resp.Err, ShouldNotBeNil)
-			So(resp.Err.Code(), ShouldEqual, skyerr.UserDisabled)
+			Convey("when user is required", func() {
+				So(pp.Preprocess(&payload, &resp), ShouldEqual, http.StatusForbidden)
+				So(resp.Err, ShouldNotBeNil)
+				So(resp.Err.Code(), ShouldEqual, skyerr.UserDisabled)
+			})
+
+			Convey("when user is not required", func() {
+				pp.Required = false
+				So(pp.Preprocess(&payload, &resp), ShouldEqual, http.StatusOK)
+				So(resp.Err, ShouldBeNil)
+			})
 		})
 
 		Convey("should create and inject user when master key is used", func() {
@@ -516,8 +524,9 @@ func TestInjectUserProcessor(t *testing.T) {
 		user := skydb.Record{
 			ID: skydb.NewRecordID("user", "userid1"),
 			Data: map[string]interface{}{
-				"username": "john.doe",
-				"email":    "john.doe@example.com",
+				"username":    "john.doe",
+				"email":       "john.doe@example.com",
+				"is_verified": false,
 			},
 		}
 
@@ -607,6 +616,34 @@ func TestInjectUserProcessor(t *testing.T) {
 				UpdaterID:  "userid2",
 			}
 			So(*payload.User, ShouldResemble, user)
+		})
+
+		Convey("should deny when user is required and check verified flag", func() {
+			pp.Required = true
+			pp.CheckVerification = true
+
+			payload := router.Payload{
+				Data:        map[string]interface{}{},
+				Meta:        map[string]interface{}{},
+				DBConn:      conn,
+				Database:    db,
+				AuthInfoID:  "userid1",
+				AuthInfo:    &authInfo,
+				AccessToken: injectUserPreprocessorAccessToken{},
+				User:        nil,
+			}
+			resp := router.Response{}
+
+			db.EXPECT().
+				Get(skydb.NewRecordID("user", "userid1"), gomock.Any()).
+				SetArg(1, user).
+				Return(nil).
+				AnyTimes()
+
+			So(pp.Preprocess(&payload, &resp), ShouldEqual, http.StatusForbidden)
+			So(resp.Err, ShouldNotBeNil)
+			So(resp.Err.Code(), ShouldEqual, skyerr.VerificationRequired)
+
 		})
 	})
 }

--- a/pkg/server/preprocessor/preprocessor_test.go
+++ b/pkg/server/preprocessor/preprocessor_test.go
@@ -506,7 +506,7 @@ func TestInjectUserProcessor(t *testing.T) {
 
 		db := mock_skydb.NewMockTxDatabase(ctrl)
 
-		pp := InjectUserIfPresent{}
+		pp := InjectUser{}
 		conn := skydbtest.NewMapConn()
 		conn.InternalPublicDB = db
 

--- a/pkg/server/router/errors.go
+++ b/pkg/server/router/errors.go
@@ -48,6 +48,7 @@ func defaultStatusCode(err skyerr.Error) int {
 		skyerr.RecordQueryDenied:       http.StatusForbidden,
 		skyerr.NotConfigured:           http.StatusServiceUnavailable,
 		skyerr.UserDisabled:            http.StatusForbidden,
+		skyerr.VerificationRequired:    http.StatusForbidden,
 	}[err.Code()]
 	if !ok {
 		if err.Code() < 10000 {

--- a/pkg/server/skyconfig/config.go
+++ b/pkg/server/skyconfig/config.go
@@ -231,6 +231,9 @@ type Configuration struct {
 		PwHistoryDays       int      `json:"pw_history_days"`
 		PwExpiryDays        int      `json:"pw_expiry_days"`
 	} `json:"user_audit"`
+	Verification struct {
+		Required bool `json:"required"`
+	} `json:"verification"`
 }
 
 func NewConfiguration() Configuration {
@@ -389,6 +392,7 @@ func (config *Configuration) ReadFromEnv() {
 	config.readLog()
 	config.readPlugins()
 	config.readUserAudit()
+	config.readUserVerification()
 }
 
 func (config *Configuration) readHost() {
@@ -686,5 +690,11 @@ func (config *Configuration) readUserAudit() {
 	}
 	if v, err := strconv.ParseInt(os.Getenv("USER_AUDIT_PW_EXPIRY_DAYS"), 10, 0); err == nil && v > 0 {
 		config.UserAudit.PwExpiryDays = int(v)
+	}
+}
+
+func (config *Configuration) readUserVerification() {
+	if v, err := parseBool(os.Getenv("VERIFY_REQUIRED")); err == nil {
+		config.Verification.Required = v
 	}
 }

--- a/pkg/server/skyerr/errorcode_string.go
+++ b/pkg/server/skyerr/errorcode_string.go
@@ -5,18 +5,18 @@ package skyerr
 import "strconv"
 
 const (
-	_ErrorCode_name_0 = "NotAuthenticatedPermissionDeniedAccessKeyNotAcceptedAccessTokenNotAcceptedInvalidCredentialsInvalidSignatureBadRequestInvalidArgumentDuplicatedResourceNotFoundNotSupportedNotImplementedConstraintViolatedIncompatibleSchemaAtomicOperationFailurePartialOperationFailureUndefinedOperationPluginUnavailablePluginTimeoutRecordQueryInvalidPluginInitializingResponseTimeoutDeniedArgumentRecordQueryDeniedNotConfiguredPasswordPolicyViolatedUserDisabled"
+	_ErrorCode_name_0 = "NotAuthenticatedPermissionDeniedAccessKeyNotAcceptedAccessTokenNotAcceptedInvalidCredentialsInvalidSignatureBadRequestInvalidArgumentDuplicatedResourceNotFoundNotSupportedNotImplementedConstraintViolatedIncompatibleSchemaAtomicOperationFailurePartialOperationFailureUndefinedOperationPluginUnavailablePluginTimeoutRecordQueryInvalidPluginInitializingResponseTimeoutDeniedArgumentRecordQueryDeniedNotConfiguredPasswordPolicyViolatedUserDisabledVerificationRequired"
 	_ErrorCode_name_1 = "UnexpectedErrorUnexpectedAuthInfoNotFoundUnexpectedUnableToOpenDatabaseUnexpectedPushNotificationNotConfiguredInternalQueryInvalidUnexpectedUserNotFound"
 )
 
 var (
-	_ErrorCode_index_0 = [...]uint16{0, 16, 32, 52, 74, 92, 108, 118, 133, 143, 159, 171, 185, 203, 221, 243, 266, 284, 301, 314, 332, 350, 365, 379, 396, 409, 431, 443}
+	_ErrorCode_index_0 = [...]uint16{0, 16, 32, 52, 74, 92, 108, 118, 133, 143, 159, 171, 185, 203, 221, 243, 266, 284, 301, 314, 332, 350, 365, 379, 396, 409, 431, 443, 463}
 	_ErrorCode_index_1 = [...]uint8{0, 15, 41, 71, 110, 130, 152}
 )
 
 func (i ErrorCode) String() string {
 	switch {
-	case 101 <= i && i <= 127:
+	case 101 <= i && i <= 128:
 		i -= 101
 		return _ErrorCode_name_0[_ErrorCode_index_0[i]:_ErrorCode_index_0[i+1]]
 	case 10000 <= i && i <= 10005:

--- a/pkg/server/skyerr/skyerr.go
+++ b/pkg/server/skyerr/skyerr.go
@@ -153,6 +153,10 @@ const (
 	// UserDisabled is returned when the user account is disabled.
 	UserDisabled
 
+	// VerificationRequired is returned when verification is required but the
+	// user is not verified.
+	VerificationRequired
+
 	// Error codes for expected error condition should be placed
 	// above this line.
 )


### PR DESCRIPTION
If the user is not allowed to access resource because of policies on user
data, such as password expiry, token expiry, disabled or not verified,
The preprocessor will still allow access if user is not required. Preprocessor
will not set AuthInfo in this case.

connects #554