### PR TITLE
WIP: Allow asset presign expire time to be configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,18 @@ CUSTOM_TOKEN_SECRET="ssosecret"
 # ASSET_STORE_S3_URL_PREFIX=
 # ASSET_STORE_SECRET=
 # ASSET_STORE_URL_PREFIX=
+#
+# When asset presign is required (i.e. when asset store is private), the
+# presigned link for the asset will become expired after the configured number
+# of seconds. Default is 15 minutes.
+# ASSET_STORE_PRESIGN_EXPIRY=900
+#
+# When asset presign is required (i.e. when asset store is private), the
+# presigned link will have its expiry calculated in predefined interval.
+# In other words, the expire time will change when each interval elapsed. Value
+# is in number of seconds. Default is 5 minutes. This should be smaller than
+# the value in ASSET_STORE_PRESIGN_EXPIRY.
+# ASSET_STORE_PRESIGN_INTERVAL=300
 
 # Used when ASSET_STORE is cloud (http://portal.skygear.io/)
 # CLOUD_ASSET_HOST=

--- a/main.go
+++ b/main.go
@@ -461,6 +461,8 @@ func initUserAuthRecordKeys(connOpener func() (skydb.Conn, error), authRecordKey
 
 func initAssetStore(config skyconfig.Configuration) asset.Store {
 	var store asset.Store
+	presignExpiry := time.Second * time.Duration(config.AssetStore.PresignExpiry)
+	presignInterval := time.Second * time.Duration(config.AssetStore.PresignInterval)
 	switch config.AssetStore.ImplName {
 	default:
 		panic("unrecgonized asset store implementation: " + config.AssetStore.ImplName)
@@ -470,6 +472,8 @@ func initAssetStore(config skyconfig.Configuration) asset.Store {
 			config.AssetStore.FileSystemStore.URLPrefix,
 			config.AssetStore.FileSystemStore.Secret,
 			config.AssetStore.Public,
+			presignExpiry,
+			presignInterval,
 		)
 	case "s3":
 		s3Store, err := asset.NewS3Store(
@@ -479,6 +483,8 @@ func initAssetStore(config skyconfig.Configuration) asset.Store {
 			config.AssetStore.S3Store.Bucket,
 			config.AssetStore.S3Store.URLPrefix,
 			config.AssetStore.Public,
+			presignExpiry,
+			presignInterval,
 		)
 		if err != nil {
 			panic("failed to initialize asset.S3Store: " + err.Error())
@@ -492,6 +498,8 @@ func initAssetStore(config skyconfig.Configuration) asset.Store {
 			config.AssetStore.CloudStore.PublicPrefix,
 			config.AssetStore.CloudStore.PrivatePrefix,
 			config.AssetStore.Public,
+			presignExpiry,
+			presignInterval,
 		)
 		if err != nil {
 			panic("Fail to initialize asset.CloudStore: " + err.Error())

--- a/pkg/server/asset/asset.go
+++ b/pkg/server/asset/asset.go
@@ -49,3 +49,18 @@ type URLSigner interface {
 type SignatureParser interface {
 	ParseSignature(signed string, name string, expiredAt time.Time) (valid bool, err error)
 }
+
+// getPresignIntervalStartTime returns the asset expiration interval start time,
+// which is added to the expiry duration to calculate the asset expiration time.
+func getPresignIntervalStartTime(now time.Time, interval time.Duration) time.Time {
+	if int64(interval) == 0 {
+		return now
+	}
+	return time.Unix((now.Unix()/int64(interval))*int64(interval), 0)
+}
+
+// getPresignExpireTime returns the asset expiration time that is consistent
+// for the duration of the current presign interval.
+func getPresignExpireTime(now time.Time, interval, expiry time.Duration) time.Time {
+	return getPresignIntervalStartTime(now, interval).Add(expiry)
+}

--- a/pkg/server/asset/asset_test.go
+++ b/pkg/server/asset/asset_test.go
@@ -1,0 +1,44 @@
+// Copyright 2015-present Oursky Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package asset
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestPresignFunctions(t *testing.T) {
+
+	Convey("Presign Interval", t, func() {
+		Convey("should calculate start time", func() {
+			now := time.Now()
+			diff := time.Minute * time.Duration(15)
+			startTime := getPresignIntervalStartTime(now, diff)
+			So(startTime.Sub(now), ShouldEqual, diff)
+		})
+	})
+
+	Convey("Presign Expire", t, func() {
+		Convey("should calculate expire time", func() {
+			now := time.Now()
+			diff := time.Minute * time.Duration(15)
+			expire := time.Minute * time.Duration(5)
+			expireTime := getPresignExpireTime(now, diff, expire)
+			So(expireTime.Sub(now), ShouldEqual, diff)
+		})
+	})
+}

--- a/pkg/server/asset/cloud_test.go
+++ b/pkg/server/asset/cloud_test.go
@@ -44,6 +44,8 @@ func TestCloudStoreCreation(t *testing.T) {
 				"http://localhost:12345/public",
 				"http://localhost:12345/private",
 				true,
+				15*60,
+				5*60,
 			)
 			store := _store.(*cloudStore)
 			defer store.signer.refreshTicker.Stop()
@@ -70,6 +72,8 @@ func TestCloudStoreCreation(t *testing.T) {
 				"http://localhost:12345/public",
 				"http://localhost:12345/private",
 				false,
+				15*60,
+				5*60,
 			)
 			store := _store.(*cloudStore)
 			defer store.signer.refreshTicker.Stop()
@@ -96,6 +100,8 @@ func TestCloudStoreCreation(t *testing.T) {
 				"http://localhost:12345/public",
 				"http://localhost:12345/private",
 				true,
+				15*60,
+				5*60,
 			)
 
 			So(err, ShouldNotBeNil)
@@ -110,6 +116,8 @@ func TestCloudStoreCreation(t *testing.T) {
 				"http://localhost:12345/public",
 				"http://localhost:12345/private",
 				true,
+				15*60,
+				5*60,
 			)
 
 			So(err, ShouldNotBeNil)
@@ -124,6 +132,8 @@ func TestCloudStoreCreation(t *testing.T) {
 				"http://localhost:12345/public",
 				"http://localhost:12345/private",
 				true,
+				15*60,
+				5*60,
 			)
 
 			So(err, ShouldNotBeNil)
@@ -138,6 +148,8 @@ func TestCloudStoreCreation(t *testing.T) {
 				"",
 				"http://localhost:12345/private",
 				true,
+				15*60,
+				5*60,
 			)
 
 			So(err, ShouldNotBeNil)
@@ -152,6 +164,8 @@ func TestCloudStoreCreation(t *testing.T) {
 				"http://localhost:12345/public",
 				"",
 				false,
+				15*60,
+				5*60,
 			)
 
 			So(err, ShouldNotBeNil)
@@ -193,6 +207,8 @@ func TestCloudStoreGetSignedURL(t *testing.T) {
 				"http://localhost:12345/public",
 				"http://localhost:12345/private",
 				true,
+				15*60,
+				5*60,
 			)
 			publicStore := _publicStore.(*cloudStore)
 			defer publicStore.signer.refreshTicker.Stop()
@@ -215,6 +231,8 @@ func TestCloudStoreGetSignedURL(t *testing.T) {
 				"http://localhost:12345/public",
 				"http://localhost:12345/private",
 				false,
+				15*60,
+				5*60,
 			)
 			publicStore := _publicStore.(*cloudStore)
 			defer publicStore.signer.refreshTicker.Stop()

--- a/pkg/server/asset/fs_test.go
+++ b/pkg/server/asset/fs_test.go
@@ -17,6 +17,8 @@ func TestFileStore(t *testing.T) {
 			"http://skygear.dev/files",
 			"asset_secret",
 			false,
+			time.Minute * time.Duration(15),
+			time.Minute * time.Duration(5),
 		}
 		Convey("Sign the Parse Signature correctly", func() {
 			s, err := fsStore.SignedURL("index.html")

--- a/pkg/server/asset/s3_test.go
+++ b/pkg/server/asset/s3_test.go
@@ -17,6 +17,8 @@ func TestS3Store(t *testing.T) {
 				"bucket-name",
 				"http://bucket-name.s3-website-us-west-1.amazonaws.com/",
 				true,
+				15*60,
+				5*60,
 			)
 			So(err, ShouldBeNil)
 			//So(s3.(s3Store).urlPrefix, ShouldEqual, "http://bucket-name.s3-website-us-east-2.amazonaws.com/")
@@ -30,6 +32,8 @@ func TestS3Store(t *testing.T) {
 				"bucket-name",
 				"http://bucket-name.s3-website-us-east-2.amazonaws.com/",
 				true,
+				15*60,
+				5*60,
 			)
 			So(err, ShouldBeNil)
 			//So(s3.(s3Store).urlPrefix, ShouldEqual, "http://bucket-name.s3-website-us-east-2.amazonaws.com/")


### PR DESCRIPTION
The presign expire time is calculated based on presign interval, which
allow the link to have consistent signature.

connects #572