### PR TITLE
Refactor how processors are injected to plugin handlers/lambdas

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,7 +131,6 @@ func main() {
 	pluginContext := plugin.Context{
 		Router:           r,
 		Mux:              serveMux,
-		Preprocessors:    preprocessorRegistry,
 		HookRegistry:     hook.NewRegistry(),
 		ProviderRegistry: provider.NewRegistry(),
 		Scheduler:        cronjob,
@@ -273,6 +272,7 @@ func main() {
 		ServiceGraph:    g,
 		PreprocessorMap: &preprocessorRegistry,
 	}
+	pluginContext.HandlerInjector = injector
 
 	r.Map("", &handler.HomeHandler{})
 	r.Map("_status:healthz", injector.Inject(&handler.HealthzHandler{}))

--- a/pkg/server/plugin/handler_test.go
+++ b/pkg/server/plugin/handler_test.go
@@ -16,7 +16,7 @@ func TestHandlerCreation(t *testing.T) {
 	Convey("create simple handler", t, func() {
 		handler := NewPluginHandler(pluginHandlerInfo{
 			Name: "hello:world",
-		}, nil, nil)
+		}, nil)
 
 		So(handler.Name, ShouldEqual, "hello:world")
 		So(handler.AccessKeyRequired, ShouldBeFalse)
@@ -27,7 +27,7 @@ func TestHandlerCreation(t *testing.T) {
 		handler := NewPluginHandler(pluginHandlerInfo{
 			Name:         "hello:world",
 			UserRequired: true,
-		}, nil, nil)
+		}, nil)
 
 		So(handler.UserRequired, ShouldBeTrue)
 	})
@@ -36,7 +36,7 @@ func TestHandlerCreation(t *testing.T) {
 		handler := NewPluginHandler(pluginHandlerInfo{
 			Name:        "hello:world",
 			KeyRequired: true,
-		}, nil, nil)
+		}, nil)
 
 		So(handler.AccessKeyRequired, ShouldBeTrue)
 	})

--- a/pkg/server/plugin/lambda_test.go
+++ b/pkg/server/plugin/lambda_test.go
@@ -30,7 +30,7 @@ func TestLambdaCreation(t *testing.T) {
 	Convey("create simple lambda", t, func() {
 		handler := NewLambdaHandler(map[string]interface{}{
 			"name": "hello:world",
-		}, nil, nil)
+		}, nil)
 
 		So(handler.Name, ShouldEqual, "hello:world")
 		So(handler.AccessKeyRequired, ShouldBeFalse)
@@ -41,7 +41,7 @@ func TestLambdaCreation(t *testing.T) {
 		handler := NewLambdaHandler(map[string]interface{}{
 			"name":          "hello:world",
 			"user_required": true,
-		}, nil, nil)
+		}, nil)
 
 		So(handler.UserRequired, ShouldBeTrue)
 	})
@@ -50,7 +50,7 @@ func TestLambdaCreation(t *testing.T) {
 		handler := NewLambdaHandler(map[string]interface{}{
 			"name":         "hello:world",
 			"key_required": true,
-		}, nil, nil)
+		}, nil)
 
 		So(handler.AccessKeyRequired, ShouldBeTrue)
 	})

--- a/pkg/server/plugin/plugin_test.go
+++ b/pkg/server/plugin/plugin_test.go
@@ -18,9 +18,9 @@ import (
 	"net/http"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
-
+	"github.com/facebookgo/inject"
 	"github.com/robfig/cron"
+	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/skygeario/skygear-server/pkg/server/router"
 	"github.com/skygeario/skygear-server/pkg/server/skyconfig"
@@ -46,6 +46,13 @@ type MockAccessKeyPreprocessor struct{}
 
 func (p MockAccessKeyPreprocessor) Preprocess(payload *router.Payload, response *router.Response) int {
 	payload.AccessKey = router.ClientAccessKey
+	return http.StatusOK
+}
+
+type MockNullPreprocessor struct {
+}
+
+func (p MockNullPreprocessor) Preprocess(payload *router.Payload, response *router.Response) int {
 	return http.StatusOK
 }
 
@@ -88,9 +95,16 @@ func TestPlugin(t *testing.T) {
 		plugin := NewPlugin("null", "/tmp/nonexistent", []string{}, config)
 		Convey("init correctly with one handler", func() {
 			mux := http.NewServeMux()
-			plugin.initHandler(mux, router.PreprocessorRegistry{
-				"inject_auth_id": MockInjectAuthIDPreprocessor{},
-				"plugin_ready":   MockPluginReadyPreprocessor{},
+			plugin.initHandler(mux, router.HandlerInjector{
+				ServiceGraph: &inject.Graph{},
+				PreprocessorMap: &router.PreprocessorRegistry{
+					"inject_auth_id": MockInjectAuthIDPreprocessor{},
+					"plugin_ready":   MockPluginReadyPreprocessor{},
+					"authenticator":  MockNullPreprocessor{},
+					"dbconn":         MockNullPreprocessor{},
+					"require_auth":   MockNullPreprocessor{},
+					"check_user":     MockNullPreprocessor{},
+				},
 			}, []pluginHandlerInfo{
 				pluginHandlerInfo{
 					Name: "chima:echo",
@@ -102,9 +116,16 @@ func TestPlugin(t *testing.T) {
 
 		Convey("init correctly with multiple handler", func() {
 			mux := http.NewServeMux()
-			plugin.initHandler(mux, router.PreprocessorRegistry{
-				"inject_auth_id": MockInjectAuthIDPreprocessor{},
-				"plugin_ready":   MockPluginReadyPreprocessor{},
+			plugin.initHandler(mux, router.HandlerInjector{
+				ServiceGraph: &inject.Graph{},
+				PreprocessorMap: &router.PreprocessorRegistry{
+					"inject_auth_id": MockInjectAuthIDPreprocessor{},
+					"plugin_ready":   MockPluginReadyPreprocessor{},
+					"authenticator":  MockNullPreprocessor{},
+					"dbconn":         MockNullPreprocessor{},
+					"require_auth":   MockNullPreprocessor{},
+					"check_user":     MockNullPreprocessor{},
+				},
 			}, []pluginHandlerInfo{
 				pluginHandlerInfo{
 					Name: "chima:echo",


### PR DESCRIPTION
This is required because we need to inject asset store to lambda in
order to support asset signing when we support returning assets.