### PR TITLE
Fix cannot login user if user record is not public read

### DIFF
--- a/pkg/server/handler/auth_test.go
+++ b/pkg/server/handler/auth_test.go
@@ -65,6 +65,9 @@ func MakeUsernameEmailQueryAssertion(username string, email string) func(query *
 	return func(query *skydb.Query, accessControlOptions *skydb.AccessControlOptions) {
 		So(query.Type, ShouldEqual, "user")
 
+		// User query should not be affected by the user record acl
+		So(accessControlOptions.BypassAccessControl, ShouldEqual, true)
+
 		predicate := query.Predicate
 		So(predicate.Operator, ShouldEqual, skydb.And)
 

--- a/pkg/server/handler/authutil.go
+++ b/pkg/server/handler/authutil.go
@@ -60,11 +60,16 @@ func (f *UserAuthFetcher) FetchAuth(authData skydb.AuthData) (authInfo skydb.Aut
 	return
 }
 
+// FetchUser fetches user record by AuthData for auth, e.g. login
+// The query should not be affected by the user record acl
+// so this function bypasses access control
 func (f *UserAuthFetcher) FetchUser(authData skydb.AuthData) (user skydb.Record, err error) {
 	query := f.buildAuthDataQuery(authData)
 
 	var results *skydb.Rows
-	results, err = f.Database.Query(&query, &skydb.AccessControlOptions{})
+	results, err = f.Database.Query(&query, &skydb.AccessControlOptions{
+		BypassAccessControl: true,
+	})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
connect #601 

For user query in auth should not be affected by the user record acl, so make it bypasses access control.