### PR TITLE
Fix fatal error, concurrent map iteration and map write when init plugins

### DIFF
--- a/pkg/server/plugin/plugin.go
+++ b/pkg/server/plugin/plugin.go
@@ -123,6 +123,7 @@ type Context struct {
 	ProviderRegistry *provider.Registry
 	Scheduler        *cron.Cron
 	Config           skyconfig.Configuration
+	sync.Mutex
 }
 
 // AddPluginConfiguration creates and appends a plugin
@@ -285,6 +286,8 @@ func (p *Plugin) IsReady() bool {
 }
 
 func (p *Plugin) processRegistrationInfo(context *Context, regInfo registrationInfo) {
+	context.Lock()
+	defer context.Unlock()
 	log.WithFields(logrus.Fields{
 		"regInfo":   regInfo,
 		"transport": p.transport,


### PR DESCRIPTION
The error occur randomly when init multiple plugins.

The error logs:
```
[s6-init] making user provided files available at /var/run/s6/etc...exited 0.
[s6-init] ensuring user provided files have correct perms...exited 0.
[fix-attrs.d] applying ownership & permissions fixes...
[fix-attrs.d] 01-fix-perms: applying...
[fix-attrs.d] 01-fix-perms: exited 0.
[fix-attrs.d] done.
[cont-init.d] executing container initialization scripts...
[cont-init.d] done.
[services.d] starting services
[services.d] done.
ln: failed to create symbolic link './node_modules': File exists
2018/07/03 04:05:09 Error in loading .env file
time="2018-07-03T04:05:09Z" level=info msg="Starting Skygear Server(v1.6.0-1-g0b2dac6)..." logger=main process=server
time="2018-07-03T04:05:09Z" level=debug msg="Version table \"_version\" does not exist in schema \"app_cloudapptest\"." logger=skydb process=server tag=migration
time="2018-07-03T04:05:09Z" level=debug msg="Database schema is uninitialized. Latest schema: \"7469be11899e\"" logger=skydb process=server tag=migration
time="2018-07-03T04:05:09Z" level=info msg="Database schema requires migration." logger=skydb process=server tag=migration
time="2018-07-03T04:05:09Z" level=info msg="Executed schema migration \"\" -> \"7469be11899e\"." logger=skydb process=server tag=migration
time="2018-07-03T04:05:09Z" level=debug msg="Querying remoteColumnTypes user" logger=skydb process=server
time="2018-07-03T04:05:09Z" level=debug msg="Executed SQL with sql.QueryRowx" args="[user app_cloudapptest]" executionCount=1 logger=skydb process=server tag=sql
sql:

    SELECT c.oid
    FROM pg_catalog.pg_class c
         LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
    WHERE c.relname = $1
      AND n.nspname = $2
time="2018-07-03T04:05:09Z" level=debug msg="Executed SQL successfully with sql.Queryx" args="[20775]" executionCount=2 logger=skydb process=server tag=sql
sql:

    SELECT a.attname,
      pg_catalog.format_type(a.atttypid, a.atttypmod)
    FROM pg_catalog.pg_attribute a
    WHERE a.attrelid = $1 AND a.attnum > 0 AND NOT a.attisdropped
time="2018-07-03T04:05:09Z" level=debug msg="Executed SQL successfully with sql.Queryx" args="[app_cloudapptest user]" executionCount=3 logger=skydb process=server tag=sql
sql:
    SELECT kcu.column_name, ccu.table_name FROM information_schema.table_constraints AS tc JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name WHERE constraint_type = 'FOREIGN KEY' AND tc.table_schema = $1 AND tc.table_name = $2
time="2018-07-03T04:05:09Z" level=debug msg="Cache remoteColumnTypes user" logger=skydb process=server
time="2018-07-03T04:05:09Z" level=debug msg="Using cached remoteColumnTypes user" logger=skydb process=server
time="2018-07-03T04:05:09Z" level=debug msg="Executed SQL successfully with sql.Queryx" args="[app_cloudapptest user]" executionCount=4 logger=skydb process=server tag=sql
sql:

    SELECT
        t.relname AS table_name,
        i.relname AS index_name,
        array_to_string(array_agg(a.attname), ',') AS column_names
    FROM
        pg_class t,
        pg_class i,
        pg_index ix,
        pg_attribute a,
        pg_namespace ns
    WHERE
        t.oid = ix.indrelid
        AND i.oid = ix.indexrelid
        AND ns.oid = t.relnamespace
        AND ns.oid = i.relnamespace
        AND a.attrelid = t.oid
        AND a.attnum = ANY(ix.indkey)
        AND t.relkind = 'r'
        AND ix.indisunique = TRUE
        AND ns.nspname = $1
        AND t.relname = $2
    GROUP BY
        ns.nspname,
        t.relname,
        i.relname;
time="2018-07-03T04:05:09Z" level=info msg="Subscription Service listening..." logger=main process=server tag=subscription
time="2018-07-03T04:05:09Z" level=debug msg="Executed SQL successfully with sql.Exec" args="[2018-07-02 04:05:09.8097768 +0000 UTC]" executionCount=1 logger=skydb process=server rowsAffected=0 tag=sql
sql:
    DELETE FROM "app_cloudapptest"."_device" WHERE token IS NULL AND last_registered_at < $1
time="2018-07-03T04:05:09Z" level=info msg="Supported plugin transports: http, exec" logger=main process=server tag=logger
time="2018-07-03T04:05:09Z" level=info msg="Listening on :3000..." logger=main process=server
time="2018-07-03T04:05:09Z" level=info msg="Wait for all plugin configurations" count=2 logger=plugin process=server tag=plugin
time="2018-07-03T04:05:09Z" level=debug msg="Hub running 0xc420224f80" logger=pubsub process=server tag=pubsub
time="2018-07-03T04:05:09Z" level=debug msg="Hub running 0xc420224cc0" logger=pubsub process=server tag=pubsub
time="2018-07-03T04:05:09Z" level=info msg="Sending init event to plugin" logger=plugin process=server retry=0 tag=plugin
time="2018-07-03T04:05:09Z" level=info msg="pq/listener: Received an event" event=0 logger=skydb process=server tag=skydb
time="2018-07-03T04:05:09Z" level=info msg="pq/listener: Listening to record_change..." logger=skydb process=server tag=skydb
time="2018-07-03T04:05:09Z" level=info msg="Get response from init" err="Post http://localhost:8000: dial tcp 127.0.0.1:8000: getsockopt: connection refused" logger=plugin out= plugin="&{0 0xc420670000 map[]}" process=server tag=plugin
time="2018-07-03T04:05:09Z" level=info msg="Transport state changes from TransportStateUninitialized to TransportStateError." logger=plugin process=server tag=plugin
time="2018-07-03T04:05:09Z" level=info msg="Sending init event to plugin" logger=plugin process=server retry=0 tag=plugin
time="2018-07-03T04:05:09Z" level=info msg="Get response from init" err="Post http://localhost:9000: dial tcp 127.0.0.1:9000: getsockopt: connection refused" logger=plugin out= plugin="&{0 0xc420670480 map[]}" process=server tag=plugin
time="2018-07-03T04:05:09Z" level=info msg="Transport state changes from TransportStateUninitialized to TransportStateError." logger=plugin process=server tag=plugin
[info] plugin: Listening 0.0.0.0 on port 9000..., {"process":"node"}
    2018-07-03 04:05:09,896 INFO      [skygear.bin:79][MainThread] Starting py-skygear(1.6.0)...
    2018-07-03 04:05:10,104 WARNI     [skygear.registry:140][MainThread] Replacing previously registered lambda 'sso/config'.
    2018-07-03 04:05:10,104 WARNI     [skygear.registry:173][MainThread] Replacing previously registered handler 'sso/iframe_handler' (GET).
    2018-07-03 04:05:10,104 WARNI     [skygear.registry:173][MainThread] Replacing previously registered handler 'sso/iframe_handler' (POST).
    2018-07-03 04:05:10,104 WARNI     [skygear.registry:173][MainThread] Replacing previously registered handler 'sso/iframe_handler' (PUT).
    2018-07-03 04:05:10,105 WARNI     [skygear.registry:140][MainThread] Replacing previously registered lambda 'sso/provider_profiles'.
    2018-07-03 04:05:10,106 INFO      [werkzeug:88][MainThread]  * Running on http://0.0.0.0:8000/ (Press CTRL+C to quit)
time="2018-07-03T04:05:11Z" level=info msg="Sending init event to plugin" logger=plugin process=server retry=1 tag=plugin
time="2018-07-03T04:05:11Z" level=info msg="Transport state changes from TransportStateError to TransportStateUninitialized." logger=plugin process=server tag=plugin
time="2018-07-03T04:05:11Z" level=info msg="Sending init event to plugin" logger=plugin process=server retry=1 tag=plugin
time="2018-07-03T04:05:11Z" level=info msg="Transport state changes from TransportStateError to TransportStateUninitialized." logger=plugin process=server tag=plugin
    2018-07-03 04:05:11,834 INFO      [werkzeug:88][Thread-1] 127.0.0.1 - - [03/Jul/2018 04:05:11] "POST / HTTP/1.1" 200 -
time="2018-07-03T04:05:11Z" level=info msg="Get response from init" err="<nil>" logger=plugin out="{\"timer\": [], \"hook\": [{\"name\": \"forgot_password.handlers.verify_code.before_user_save_hook\", \"trigger\": \"beforeSave\", \"async\": false, \"type\": \"user\"}, {\"name\": \"forgot_password.handlers.verify_code.after_user_save_hook\", \"trigger\": \"afterSave\", \"async\": true, \"type\": \"user\"}], \"provider\": [], \"event\": [{\"name\": \"init\"}, {\"name\": \"before-plugins-ready\"}, {\"name\": \"after-plugins-ready\"}, {\"name\": \"schema-changed\"}], \"op\": [{\"name\": \"user:forgot-password\", \"key_required\": false, \"user_required\": false}, {\"name\": \"user:forgot-password:test\", \"key_required\": true, \"user_required\": false}, {\"name\": \"user:reset-password\", \"key_required\": false, \"user_required\": false}, {\"name\": \"user:verify_code\", \"key_required\": false, \"user_required\": false}, {\"name\": \"user:verify_request\", \"key_required\": false, \"user_required\": false}, {\"name\": \"user:verify_request:test\", \"key_required\": true, \"user_required\": false}, {\"name\": \"push_campaign:get_all\", \"key_required\": false, \"user_required\": true}, {\"name\": \"push_campaign:create_new\", \"key_required\": false, \"user_required\": true}, {\"name\": \"imported_file:get_all\", \"key_required\": false, \"user_required\": true}, {\"name\": \"imported_file:create\", \"key_required\": false, \"user_required\": true}, {\"name\": \"sso/config\", \"key_required\": false, \"user_required\": false}, {\"name\": \"sso/provider_profiles\", \"key_required\": false, \"user_required\": true}], \"handler\": [{\"methods\": [\"GET\"], \"name\": \"reset-password\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"POST\"], \"name\": \"reset-password\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"GET\"], \"name\": \"user:verify-code:form\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"POST\"], \"name\": \"user:verify-code:form\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"GET\"], \"name\": \"cms/\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"POST\"], \"name\": \"cms/\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"PUT\"], \"name\": \"cms/\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"GET\"], \"name\": \"cms-api/\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"POST\"], \"name\": \"cms-api/\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"PUT\"], \"name\": \"cms-api/\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"GET\"], \"name\": \"cms-api/export\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"POST\"], \"name\": \"cms-api/export\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"PUT\"], \"name\": \"cms-api/export\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"GET\"], \"name\": \"cms-api/import\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"POST\"], \"name\": \"cms-api/import\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"PUT\"], \"name\": \"cms-api/import\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"GET\"], \"name\": \"cms-api/default-cms-config.yaml\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"POST\"], \"name\": \"cms-api/default-cms-config.yaml\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"PUT\"], \"name\": \"cms-api/default-cms-config.yaml\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"GET\"], \"name\": \"sso/iframe_handler\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"POST\"], \"name\": \"sso/iframe_handler\", \"key_required\": false, \"user_required\": false}, {\"methods\": [\"PUT\"], \"name\": \"sso/iframe_handler\", \"key_required\": false, \"user_required\": false}]}" plugin="&{1 0xc420670000 map[]}" process=server tag=plugin
time="2018-07-03T04:05:11Z" level=info msg="Get response from init" err="<nil>" logger=plugin out="{\"op\":[{\"name\":\"op1\"},{\"name\":\"op:user\",\"key_required\":true,\"user_required\":true}],\"event\":[{\"name\":\"init\"}],\"handler\":[{\"name\":\"static/\",\"methods\":[\"GET\"],\"user_required\":false},{\"name\":\"static/\",\"methods\":[\"POST\"],\"user_required\":false},{\"name\":\"static/\",\"methods\":[\"PUT\"],\"user_required\":false}],\"hook\":[{\"async\":false,\"type\":\"note\",\"trigger\":\"beforeSave\",\"name\":\"user1\"},{\"type\":\"note\",\"trigger\":\"afterSave\",\"name\":\"user1-1\"},{\"type\":\"note\",\"trigger\":\"beforeDelete\",\"name\":\"c26c8cdfa62ca8d9b72f43f6ade496f009c5b43d\"},{\"type\":\"note\",\"trigger\":\"afterDelete\",\"name\":\"b1842f59fc5b6182a48481abf47f7e0e3ca5494e\"}],\"timer\":[{\"spec\":\"@every 60s\",\"name\":\"minute\"},{\"spec\":\"@every 30s\",\"name\":\"cbc3b38d9dfc8817219e9ab302d1fdf5cc21a9c4\"}],\"provider\":[]}" plugin="&{1 0xc420670480 map[]}" process=server tag=plugin
fatal error: concurrent map iteration and map write

goroutine 37 [running]:
runtime.throw(0xc91e06, 0x26)
	/usr/local/go/src/runtime/panic.go:605 +0x95 fp=0xc420d73590 sp=0xc420d73570 pc=0x42c3e5
runtime.mapiternext(0xc420d736c8)
	/usr/local/go/src/runtime/hashmap.go:778 +0x6f1 fp=0xc420d73628 sp=0xc420d73590 pc=0x40b811
github.com/skygeario/skygear-server/vendor/github.com/facebookgo/inject.(*Graph).Populate(0xc420224d80, 0xc420d73778, 0x1)
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/facebookgo/inject/inject.go:157 +0x95 fp=0xc420d73738 sp=0xc420d73628 pc=0x7423e5
github.com/skygeario/skygear-server/pkg/server/router.(*HandlerInjector).InjectServices(0xc420d73908, 0x1129ba0, 0xc420298a50, 0xc420519d40, 0xc420298a50)
	/go/src/github.com/skygeario/skygear-server/pkg/server/router/inject.go:44 +0x1d6 fp=0xc420d73800 sp=0xc420d73738 pc=0x912546
github.com/skygeario/skygear-server/pkg/server/router.(*HandlerInjector).Inject(0xc420d73908, 0x1129ba0, 0xc420298a50, 0xd, 0xc420519de8)
	/go/src/github.com/skygeario/skygear-server/pkg/server/router/inject.go:74 +0x3f fp=0xc420d73838 sp=0xc420d73800 pc=0x912cdf
github.com/skygeario/skygear-server/pkg/server/plugin.(*Plugin).initLambda(0xc42023ea60, 0xc420224c00, 0xc420224d80, 0xc42000e220, 0xc4200f5810, 0xc, 0xd)
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:330 +0x2f9 fp=0xc420d738f8 sp=0xc420d73838 pc=0x9b4ab9
github.com/skygeario/skygear-server/pkg/server/plugin.(*Plugin).processRegistrationInfo(0xc42023ea60, 0xc420516000, 0xc420644300, 0x16, 0x1c, 0xc4201520e0, 0x2, 0x4, 0xc4200f5810, 0xc, ...)
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:293 +0x30f fp=0xc420d73da0 sp=0xc420d738f8 pc=0x9b3c8f
github.com/skygeario/skygear-server/pkg/server/plugin.(*Plugin).Init(0xc42023ea60, 0xc420516000)
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:246 +0x3d9 fp=0xc420d73fa0 sp=0xc420d73da0 pc=0x9b31a9
github.com/skygeario/skygear-server/pkg/server/plugin.(*Context).InitPlugins.func1(0xc420421b00, 0xc420516000, 0xc42023ea60)
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:150 +0x5b fp=0xc420d73fc8 sp=0xc420d73fa0 pc=0x9b639b
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:2337 +0x1 fp=0xc420d73fd0 sp=0xc420d73fc8 pc=0x45a181
created by github.com/skygeario/skygear-server/pkg/server/plugin.(*Context).InitPlugins
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:148 +0xaa

goroutine 1 [IO wait]:
internal/poll.runtime_pollWait(0x7f396dbdef70, 0x72, 0xffffffffffffffff)
	/usr/local/go/src/runtime/netpoll.go:173 +0x57
internal/poll.(*pollDesc).wait(0xc42014a818, 0x72, 0xc420d76900, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:85 +0xae
internal/poll.(*pollDesc).waitRead(0xc42014a818, 0xffffffffffffff00, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:90 +0x3d
internal/poll.(*FD).Accept(0xc42014a800, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:335 +0x1e2
net.(*netFD).accept(0xc42014a800, 0x7f396dc3a000, 0x0, 0xcf0688)
	/usr/local/go/src/net/fd_unix.go:238 +0x42
net.(*TCPListener).accept(0xc4202b2098, 0xc420d76b00, 0x412cf8, 0x30)
	/usr/local/go/src/net/tcpsock_posix.go:136 +0x2e
net.(*TCPListener).AcceptTCP(0xc4202b2098, 0xc4202a9770, 0xc4202a9770, 0xb7d300)
	/usr/local/go/src/net/tcpsock.go:234 +0x49
net/http.tcpKeepAliveListener.Accept(0xc4202b2098, 0xc420018068, 0xb7d300, 0x11bca60, 0xc5fde0)
	/usr/local/go/src/net/http/server.go:3120 +0x2f
net/http.(*Server).Serve(0xc420149860, 0x112bae0, 0xc4202b2098, 0x0, 0x0)
	/usr/local/go/src/net/http/server.go:2695 +0x1b2
net/http.(*Server).ListenAndServe(0xc420149860, 0xc420149860, 0x1)
	/usr/local/go/src/net/http/server.go:2636 +0xa9
net/http.ListenAndServe(0xc78bff, 0x5, 0x1120ce0, 0xc420161f60, 0x1, 0x1)
	/usr/local/go/src/net/http/server.go:2882 +0x7f
main.main()
	/go/src/github.com/skygeario/skygear-server/main.go:404 +0x3a4d

goroutine 8 [chan receive]:
database/sql.(*DB).connectionOpener(0xc420076dc0)
	/usr/local/go/src/database/sql/sql.go:871 +0x53
created by database/sql.Open
	/usr/local/go/src/database/sql/sql.go:609 +0x1ee

goroutine 21 [chan receive]:
github.com/skygeario/skygear-server/pkg/server/skydb/pq.dbInitializer()
	/go/src/github.com/skygeario/skygear-server/pkg/server/skydb/pq/pq.go:122 +0x71
created by github.com/skygeario/skygear-server/pkg/server/skydb/pq.init.1
	/go/src/github.com/skygeario/skygear-server/pkg/server/skydb/pq/pq.go:168 +0x66

goroutine 38 [runnable]:
github.com/skygeario/skygear-server/vendor/github.com/facebookgo/inject.parseTag(0x0, 0x0, 0xad0a14, 0xc, 0x0)
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/facebookgo/inject/inject.go:544 +0x22e
github.com/skygeario/skygear-server/vendor/github.com/facebookgo/inject.(*Graph).populateExplicit(0xc420224d80, 0xc4206b1740, 0x0, 0x0)
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/facebookgo/inject/inject.go:224 +0x29e
github.com/skygeario/skygear-server/vendor/github.com/facebookgo/inject.(*Graph).Populate(0xc420224d80, 0xc420649690, 0x1)
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/facebookgo/inject/inject.go:162 +0xcb
github.com/skygeario/skygear-server/pkg/server/router.(*HandlerInjector).InjectServices(0xc420649908, 0x1129b60, 0xc4203154a0, 0xc42017c901, 0xc4203154a0)
	/go/src/github.com/skygeario/skygear-server/pkg/server/router/inject.go:44 +0x1d6
github.com/skygeario/skygear-server/pkg/server/router.(*HandlerInjector).Inject(0xc420649908, 0x1129b60, 0xc4203154a0, 0xc420649820, 0x2)
	/go/src/github.com/skygeario/skygear-server/pkg/server/router/inject.go:74 +0x3f
github.com/skygeario/skygear-server/pkg/server/plugin.(*Plugin).initHandler(0xc42023ea80, 0xc42063ebd0, 0xc420224d80, 0xc42000e220, 0xc4201bc000, 0x3, 0x4, 0xc78bff, 0x5, 0xc420014089, ...)
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:306 +0x325
github.com/skygeario/skygear-server/pkg/server/plugin.(*Plugin).processRegistrationInfo(0xc42023ea80, 0xc420516000, 0xc4201bc000, 0x3, 0x4, 0xc4201bc0e0, 0x4, 0x4, 0xc4203cc500, 0x2, ...)
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:292 +0x2b4
github.com/skygeario/skygear-server/pkg/server/plugin.(*Plugin).Init(0xc42023ea80, 0xc420516000)
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:246 +0x3d9
github.com/skygeario/skygear-server/pkg/server/plugin.(*Context).InitPlugins.func1(0xc420421b00, 0xc420516000, 0xc42023ea80)
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:150 +0x5b
created by github.com/skygeario/skygear-server/pkg/server/plugin.(*Context).InitPlugins
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:148 +0xaa

goroutine 39 [semacquire]:
sync.runtime_Semacquire(0xc420421b0c)
	/usr/local/go/src/runtime/sema.go:56 +0x39
sync.(*WaitGroup).Wait(0xc420421b00)
	/usr/local/go/src/sync/waitgroup.go:131 +0x72
github.com/skygeario/skygear-server/pkg/server/plugin.(*Context).InitPlugins.func2(0xc420516000, 0xc420421b00)
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:159 +0xf8
created by github.com/skygeario/skygear-server/pkg/server/plugin.(*Context).InitPlugins
	/go/src/github.com/skygeario/skygear-server/pkg/server/plugin/plugin.go:155 +0xf2

goroutine 36 [select]:
github.com/skygeario/skygear-server/vendor/github.com/robfig/cron.(*Cron).run(0xc420224c40)
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/robfig/cron/cron.go:152 +0x644
created by github.com/skygeario/skygear-server/vendor/github.com/robfig/cron.(*Cron).Start
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/robfig/cron/cron.go:127 +0x43

goroutine 15 [chan receive]:
github.com/skygeario/skygear-server/vendor/github.com/lib/pq.(*Listener).listenerConnLoop(0xc4200f43f0)
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/lib/pq/notify.go:773 +0x250
github.com/skygeario/skygear-server/vendor/github.com/lib/pq.(*Listener).listenerMain(0xc4200f43f0)
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/lib/pq/notify.go:792 +0x2b
created by github.com/skygeario/skygear-server/vendor/github.com/lib/pq.NewDialListener
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/lib/pq/notify.go:464 +0x17d

goroutine 14 [select]:
github.com/skygeario/skygear-server/pkg/server/skydb/pq.(*recordListener).Listen(0xc42023e480)
	/go/src/github.com/skygeario/skygear-server/pkg/server/skydb/pq/listener.go:118 +0x24e
created by github.com/skygeario/skygear-server/pkg/server/skydb/pq.(*conn).Subscribe.func1
	/go/src/github.com/skygeario/skygear-server/pkg/server/skydb/pq/listener.go:44 +0x4f

goroutine 13 [chan receive]:
database/sql.(*DB).connectionOpener(0xc4201e8140)
	/usr/local/go/src/database/sql/sql.go:871 +0x53
created by database/sql.Open
	/usr/local/go/src/database/sql/sql.go:609 +0x1ee

goroutine 28 [select]:
github.com/skygeario/skygear-server/pkg/server/subscription.(*Service).Run(0xc42022dd40)
	/go/src/github.com/skygeario/skygear-server/pkg/server/subscription/service.go:50 +0x22e
created by main.initSubscription
	/go/src/github.com/skygeario/skygear-server/main.go:650 +0x1ca

goroutine 29 [select]:
github.com/skygeario/skygear-server/pkg/server/pubsub.(*Hub).run(0xc420224f80)
	/go/src/github.com/skygeario/skygear-server/pkg/server/pubsub/hub.go:58 +0x28f
created by github.com/skygeario/skygear-server/pkg/server/pubsub.NewWsPubsub
	/go/src/github.com/skygeario/skygear-server/pkg/server/pubsub/ws.go:62 +0x149

goroutine 30 [select]:
github.com/skygeario/skygear-server/pkg/server/pubsub.(*Hub).run(0xc420224cc0)
	/go/src/github.com/skygeario/skygear-server/pkg/server/pubsub/hub.go:58 +0x28f
created by github.com/skygeario/skygear-server/pkg/server/pubsub.NewWsPubsub
	/go/src/github.com/skygeario/skygear-server/pkg/server/pubsub/ws.go:62 +0x149

goroutine 48 [IO wait]:
internal/poll.runtime_pollWait(0x7f396dbdedf0, 0x72, 0x0)
	/usr/local/go/src/runtime/netpoll.go:173 +0x57
internal/poll.(*pollDesc).wait(0xc42014a798, 0x72, 0xffffffffffffff00, 0x1125520, 0x111e6b0)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:85 +0xae
internal/poll.(*pollDesc).waitRead(0xc42014a798, 0xc42066c000, 0x1000, 0x1000)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:90 +0x3d
internal/poll.(*FD).Read(0xc42014a780, 0xc42066c000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:126 +0x18a
net.(*netFD).Read(0xc42014a780, 0xc42066c000, 0x1000, 0x1000, 0x12, 0x0, 0x0)
	/usr/local/go/src/net/fd_unix.go:202 +0x52
net.(*conn).Read(0xc4202b2088, 0xc42066c000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:176 +0x6d
bufio.(*Reader).Read(0xc420416f00, 0xc4200a4b20, 0x5, 0x200, 0x405c6c, 0xc420147080, 0x4)
	/usr/local/go/src/bufio/bufio.go:213 +0x30b
io.ReadAtLeast(0x111ffa0, 0xc420416f00, 0xc4200a4b20, 0x5, 0x200, 0x5, 0x0, 0x0, 0x0)
	/usr/local/go/src/io/io.go:309 +0x86
io.ReadFull(0x111ffa0, 0xc420416f00, 0xc4200a4b20, 0x5, 0x200, 0x454720, 0xc4206b02a0, 0xc420029ee0)
	/usr/local/go/src/io/io.go:327 +0x58
github.com/skygeario/skygear-server/vendor/github.com/lib/pq.(*conn).recvMessage(0xc4200a4b00, 0xc4206a7f48, 0xc420029f01, 0x0, 0x0)
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/lib/pq/conn.go:947 +0x14e
github.com/skygeario/skygear-server/vendor/github.com/lib/pq.(*ListenerConn).listenerConnLoop(0xc42005b200, 0x0, 0x0)
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/lib/pq/notify.go:139 +0xc1
github.com/skygeario/skygear-server/vendor/github.com/lib/pq.(*ListenerConn).listenerConnMain(0xc42005b200)
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/lib/pq/notify.go:188 +0x2f
created by github.com/skygeario/skygear-server/vendor/github.com/lib/pq.newDialListenerConn
	/go/src/github.com/skygeario/skygear-server/vendor/github.com/lib/pq/notify.go:81 +0x142

goroutine 73 [IO wait]:
internal/poll.runtime_pollWait(0x7f396dbded30, 0x72, 0x0)
	/usr/local/go/src/runtime/netpoll.go:173 +0x57
internal/poll.(*pollDesc).wait(0xc4206b6398, 0x72, 0xffffffffffffff00, 0x1125520, 0x111e6b0)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:85 +0xae
internal/poll.(*pollDesc).waitRead(0xc4206b6398, 0xc4206bf000, 0x1000, 0x1000)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:90 +0x3d
internal/poll.(*FD).Read(0xc4206b6380, 0xc4206bf000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:126 +0x18a
net.(*netFD).Read(0xc4206b6380, 0xc4206bf000, 0x1000, 0x1000, 0x42e0db, 0xc420408a40, 0x456530)
	/usr/local/go/src/net/fd_unix.go:202 +0x52
net.(*conn).Read(0xc4202b2408, 0xc4206bf000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:176 +0x6d
net/http.(*persistConn).Read(0xc420518fc0, 0xc4206bf000, 0x1000, 0x1000, 0xc42067aab2, 0xc4203ed4f8, 0x454720)
	/usr/local/go/src/net/http/transport.go:1391 +0x140
bufio.(*Reader).fill(0xc4206b0960)
	/usr/local/go/src/bufio/bufio.go:97 +0x11a
bufio.(*Reader).Peek(0xc4206b0960, 0x1, 0x0, 0x0, 0x0, 0xc4203ed3e0, 0x0)
	/usr/local/go/src/bufio/bufio.go:129 +0x3a
net/http.(*persistConn).readLoop(0xc420518fc0)
	/usr/local/go/src/net/http/transport.go:1539 +0x185
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1186 +0xa2e

goroutine 74 [select]:
net/http.(*persistConn).writeLoop(0xc420518fc0)
	/usr/local/go/src/net/http/transport.go:1759 +0x165
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1187 +0xa53
[cmd] /boot exited 2
execlineb: fatal: unable to exec killall: No such file or directory
execlineb: fatal: unable to exec killall: No such file or directory
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
[s6-finish] syncing disks.
[s6-finish] sending all processes the TERM signal.
[s6-finish] sending all processes the KILL signal and exiting.
```