### PR TITLE
Fix `make vendor` error on case insensitive file system

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,7 @@
 
 [[projects]]
   digest = "1:1fd88d3ff234e279084ffffc82ef09f1e22e94a26d9046d1ffaeae797e3d38c8"
-  name = "github.com/SkygearIO/buford"
+  name = "github.com/skygeario/buford"
   packages = ["push"]
   pruneopts = ""
   revision = "3b55ce646fcee15aeaff656fad74506459dfa8f6"
@@ -489,7 +489,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/SkygearIO/buford/push",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/credentials",
     "github.com/aws/aws-sdk-go/aws/session",
@@ -520,6 +519,7 @@
     "github.com/rifflock/lfshook",
     "github.com/robfig/cron",
     "github.com/sirupsen/logrus",
+    "github.com/skygeario/buford/push",
     "github.com/skygeario/go-baidupush",
     "github.com/smartystreets/goconvey/convey",
     "github.com/twinj/uuid",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,10 +28,6 @@ required = [
 ]
 
 [[constraint]]
-  name = "github.com/SkygearIO/buford"
-  revision = "3b55ce646fcee15aeaff656fad74506459dfa8f6"
-
-[[constraint]]
   name = "github.com/aws/aws-sdk-go"
   version = "~1.10.50"
 
@@ -106,6 +102,10 @@ required = [
 [[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "1.0.1"
+
+[[constraint]]
+  name = "github.com/skygeario/buford"
+  revision = "3b55ce646fcee15aeaff656fad74506459dfa8f6"
 
 [[constraint]]
   name = "github.com/smartystreets/goconvey"

--- a/pkg/server/plugin/zmq/broker.go
+++ b/pkg/server/plugin/zmq/broker.go
@@ -135,7 +135,7 @@ func requestToChannelKey(requestID string, bounceCount int) string {
 // 1. Shutdown signal, which signifies a normal termination of worker to provide
 //    a fast path of worker removal
 // 2. Extra frames for bidirectional and multiplexing, see below
-//    Related issue: https://github.com/SkygearIO/skygear-server/issues/295
+//    Related issue: https://github.com/skygeario/skygear-server/issues/295
 //
 // TODO: channeler can be separated into a separate struct, communiate with
 // broker using frontend chan, workers and pull/push sock address.

--- a/pkg/server/push/apns.go
+++ b/pkg/server/push/apns.go
@@ -19,8 +19,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/SkygearIO/buford/push"
 	"github.com/sirupsen/logrus"
+	"github.com/skygeario/buford/push"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 )
 

--- a/pkg/server/push/apns_test.go
+++ b/pkg/server/push/apns_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SkygearIO/buford/push"
+	"github.com/skygeario/buford/push"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/server/push/cert_apns.go
+++ b/pkg/server/push/cert_apns.go
@@ -23,8 +23,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/SkygearIO/buford/push"
 	"github.com/sirupsen/logrus"
+	"github.com/skygeario/buford/push"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 )
 

--- a/pkg/server/push/cert_apns_test.go
+++ b/pkg/server/push/cert_apns_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SkygearIO/buford/push"
+	"github.com/skygeario/buford/push"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 	. "github.com/skygeario/skygear-server/pkg/server/skytest"
 	. "github.com/smartystreets/goconvey/convey"

--- a/pkg/server/push/token_apns.go
+++ b/pkg/server/push/token_apns.go
@@ -25,9 +25,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/SkygearIO/buford/push"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/sirupsen/logrus"
+	"github.com/skygeario/buford/push"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 )
 

--- a/pkg/server/push/token_apns_test.go
+++ b/pkg/server/push/token_apns_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SkygearIO/buford/push"
+	"github.com/skygeario/buford/push"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 	. "github.com/skygeario/skygear-server/pkg/server/skytest"
 	. "github.com/smartystreets/goconvey/convey"


### PR DESCRIPTION
During installation of dependencies on case insensitive file system, the following command would be executed one after another, which cause an error:

1. `mkdir $GOPATH/src/github.com/skygeario`
1. `mkdir $GOPATH/src/github.com/SkygearIO`
