### PR TITLE
Move dependency logic to handler factory

### DIFF
--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -15,12 +15,13 @@ import (
 )
 
 func main() {
-	authDependency := dependency.AuthDependency{}
-	authDependency.SetDBProvider(db.RealDBProvider{})
+	authDependency := dependency.AuthDependency{
+		DB: &db.DBProvider{},
+	}
 
-	server := server.NewServer("localhost:3000", authDependency)
+	server := server.NewServer("localhost:3000")
 
-	server.Handle("/", &handler.LoginHandlerFactory{}).Methods("POST")
+	handler.AttachLoginHandler(&server, authDependency)
 
 	go func() {
 		log.Printf("Auth gear boot")

--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -8,14 +8,14 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/skygeario/skygear-server/pkg/auth/dependency"
 	"github.com/skygeario/skygear-server/pkg/auth/handler"
+	"github.com/skygeario/skygear-server/pkg/auth/provider"
 	"github.com/skygeario/skygear-server/pkg/core/db"
 	"github.com/skygeario/skygear-server/pkg/core/server"
 )
 
 func main() {
-	authDependency := dependency.AuthDependency{
+	authDependency := provider.AuthProviders{
 		DB: &db.DBProvider{},
 	}
 

--- a/pkg/auth/dependency/dependency.go
+++ b/pkg/auth/dependency/dependency.go
@@ -6,25 +6,13 @@ import (
 )
 
 type AuthDependency struct {
-	dbProvider *db.DBProvider
-}
-
-// SetDBProvider set a DB provider implementation to dependency graph
-func (d *AuthDependency) SetDBProvider(dbProvider db.DBProvider) {
-	d.dbProvider = &dbProvider
+	DB *db.DBProvider
 }
 
 func (d AuthDependency) Provide(dependencyName string, tConfig config.TenantConfiguration) interface{} {
 	switch dependencyName {
 	case "DB":
-		return func() db.IDB {
-			dbProvider := d.dbProvider
-			if dbProvider == nil {
-				return nil
-			}
-
-			return (*dbProvider).GetDB(tConfig)
-		}
+		return d.DB.Provide(tConfig)
 	default:
 		return nil
 	}

--- a/pkg/auth/handler/login.go
+++ b/pkg/auth/handler/login.go
@@ -4,23 +4,39 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/skygeario/skygear-server/pkg/auth/dependency"
 	"github.com/skygeario/skygear-server/pkg/core/config"
 	"github.com/skygeario/skygear-server/pkg/core/db"
 	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/server"
 )
 
-type LoginHandlerFactory struct{}
+func AttachLoginHandler(
+	server *server.Server,
+	authDependency dependency.AuthDependency,
+) *server.Server {
+	server.Handle("/", &LoginHandlerFactory{
+		authDependency,
+	}).Methods("POST")
+	return server
+}
+
+type LoginHandlerFactory struct {
+	Dependency dependency.AuthDependency
+}
 
 func (f LoginHandlerFactory) NewHandler(tenantConfig config.TenantConfiguration) handler.Handler {
-	return &LoginHandler{}
+	h := &LoginHandler{}
+	handler.DefaultInject(h, f.Dependency, tenantConfig)
+	return h
 }
 
 // LoginHandler handles login request
 type LoginHandler struct {
-	db.GetDB `dependency:"DB"`
+	DB db.IDB `dependency:"DB"`
 }
 
 func (h LoginHandler) Handle(ctx handler.Context) {
 	input, _ := ioutil.ReadAll(ctx.Request.Body)
-	fmt.Fprintln(ctx.ResponseWriter, `{"user": "`+h.GetDB().GetRecord("user:"+string(input))+`"}`)
+	fmt.Fprintln(ctx.ResponseWriter, `{"user": "`+h.DB.GetRecord("user:"+string(input))+`"}`)
 }

--- a/pkg/auth/handler/login.go
+++ b/pkg/auth/handler/login.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/skygeario/skygear-server/pkg/auth/dependency"
+	"github.com/skygeario/skygear-server/pkg/auth/provider"
 	"github.com/skygeario/skygear-server/pkg/core/config"
 	"github.com/skygeario/skygear-server/pkg/core/db"
 	"github.com/skygeario/skygear-server/pkg/core/handler"
@@ -13,7 +13,7 @@ import (
 
 func AttachLoginHandler(
 	server *server.Server,
-	authDependency dependency.AuthDependency,
+	authDependency provider.AuthProviders,
 ) *server.Server {
 	server.Handle("/", &LoginHandlerFactory{
 		authDependency,
@@ -22,7 +22,7 @@ func AttachLoginHandler(
 }
 
 type LoginHandlerFactory struct {
-	Dependency dependency.AuthDependency
+	Dependency provider.AuthProviders
 }
 
 func (f LoginHandlerFactory) NewHandler(tenantConfig config.TenantConfiguration) handler.Handler {

--- a/pkg/auth/provider/provider.go
+++ b/pkg/auth/provider/provider.go
@@ -1,15 +1,15 @@
-package dependency
+package provider
 
 import (
 	"github.com/skygeario/skygear-server/pkg/core/config"
 	"github.com/skygeario/skygear-server/pkg/core/db"
 )
 
-type AuthDependency struct {
+type AuthProviders struct {
 	DB *db.DBProvider
 }
 
-func (d AuthDependency) Provide(dependencyName string, tConfig config.TenantConfiguration) interface{} {
+func (d AuthProviders) Provide(dependencyName string, tConfig config.TenantConfiguration) interface{} {
 	switch dependencyName {
 	case "DB":
 		return d.DB.Provide(tConfig)

--- a/pkg/core/db/db.go
+++ b/pkg/core/db/db.go
@@ -2,18 +2,11 @@ package db
 
 import "github.com/skygeario/skygear-server/pkg/core/config"
 
-// DBProvider is the interface to get db with configuration
-type DBProvider interface {
-	GetDB(config.TenantConfiguration) IDB
-}
+type DBProvider struct{}
 
-type RealDBProvider struct{}
-
-func (p RealDBProvider) GetDB(tConfig config.TenantConfiguration) IDB {
+func (p DBProvider) Provide(tConfig config.TenantConfiguration) IDB {
 	return &DB{tConfig.DBConnectionStr}
 }
-
-type GetDB func() IDB
 
 type IDB interface {
 	GetRecord(string) string

--- a/pkg/core/handler/factory.go
+++ b/pkg/core/handler/factory.go
@@ -10,13 +10,13 @@ type Factory interface {
 	NewHandler(config.TenantConfiguration) Handler
 }
 
-type DependencyGraph interface {
+type ProviderGraph interface {
 	Provide(name string, configuration config.TenantConfiguration) interface{}
 }
 
 func DefaultInject(
 	h Handler,
-	dependencyGraph DependencyGraph,
+	dependencyGraph ProviderGraph,
 	configuration config.TenantConfiguration,
 ) {
 	t := reflect.TypeOf(h).Elem()

--- a/pkg/core/handler/factory.go
+++ b/pkg/core/handler/factory.go
@@ -1,9 +1,32 @@
 package handler
 
 import (
+	"reflect"
+
 	"github.com/skygeario/skygear-server/pkg/core/config"
 )
 
 type Factory interface {
 	NewHandler(config.TenantConfiguration) Handler
+}
+
+type DependencyGraph interface {
+	Provide(name string, configuration config.TenantConfiguration) interface{}
+}
+
+func DefaultInject(
+	h Handler,
+	dependencyGraph DependencyGraph,
+	configuration config.TenantConfiguration,
+) {
+	t := reflect.TypeOf(h).Elem()
+	v := reflect.ValueOf(h).Elem()
+
+	numField := t.NumField()
+	for i := 0; i < numField; i++ {
+		dependencyName := t.Field(i).Tag.Get("dependency")
+		field := v.Field(i)
+		dependency := dependencyGraph.Provide(dependencyName, configuration)
+		field.Set(reflect.ValueOf(dependency))
+	}
 }


### PR DESCRIPTION
Server should not aware of the dependency, while handler factory should.
Here we try to move the mount path information to handler instead of
main.go. It is because the where is mount related more to the business
logic of a handler than how the server boot.

connect #630 