### PR TITLE
next: Gear logging

### DIFF
--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -48,6 +48,8 @@ func main() {
 		}.Handle)
 	}
 
+	srv.Use(middleware.RequestIDMiddleware{}.Handle)
+
 	handler.AttachSignupHandler(&srv, authDependency)
 	handler.AttachLoginHandler(&srv, authDependency)
 	handler.AttachMeHandler(&srv, authDependency)

--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/skygeario/skygear-server/pkg/core/config"
 	"github.com/skygeario/skygear-server/pkg/core/middleware"
 	"github.com/skygeario/skygear-server/pkg/core/server"
+	"github.com/skygeario/skygear-server/pkg/core/logging"
 )
 
 type configuration struct {
@@ -32,6 +33,9 @@ func main() {
 
 	configuration := configuration{}
 	envconfig.Process("", &configuration)
+
+	// logging initialization
+	logging.SetModule("auth")
 
 	authDependency := auth.NewDependencyMap()
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -19,7 +19,10 @@ import (
 var config gatewayConfig.Configuration
 
 func init() {
-	logger := logging.CreateLogger("gateway")
+	// logging initialization
+	logging.SetModule("gateway")
+
+	logger := logging.LoggerEntry("gateway")
 	if err := config.ReadFromEnv(); err != nil {
 		logger.WithError(err).Panic(
 			"Fail to load config for starting gateway server")
@@ -29,7 +32,7 @@ func init() {
 }
 
 func main() {
-	logger := logging.CreateLogger("gateway")
+	logger := logging.LoggerEntry("gateway")
 
 	// create gateway store
 	store, connErr := db.NewGatewayStore(

--- a/pkg/auth/handler/disable.go
+++ b/pkg/auth/handler/disable.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"time"
 	"encoding/json"
 	"net/http"
@@ -10,7 +9,6 @@ import (
 	"github.com/skygeario/skygear-server/pkg/core/auth/authinfo"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz/policy"
-	"github.com/skygeario/skygear-server/pkg/core/config"
 	"github.com/skygeario/skygear-server/pkg/core/handler"
 	"github.com/skygeario/skygear-server/pkg/core/inject"
 	"github.com/skygeario/skygear-server/pkg/core/server"
@@ -35,9 +33,9 @@ type SetDisableHandlerFactory struct {
 }
 
 // NewHandler creates new SetDisableHandler
-func (f SetDisableHandlerFactory) NewHandler(ctx context.Context, tenantConfig config.TenantConfiguration) handler.Handler {
+func (f SetDisableHandlerFactory) NewHandler(request *http.Request) handler.Handler {
 	h := &SetDisableHandler{}
-	inject.DefaultInject(h, f.Dependency, ctx, tenantConfig)
+	inject.DefaultInject(h, f.Dependency, request)
 	return handler.APIHandlerToHandler(h)
 }
 

--- a/pkg/auth/handler/login.go
+++ b/pkg/auth/handler/login.go
@@ -1,13 +1,11 @@
 package handler
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/skygeario/skygear-server/pkg/auth"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz/policy"
-	"github.com/skygeario/skygear-server/pkg/core/config"
 	"github.com/skygeario/skygear-server/pkg/core/handler"
 	"github.com/skygeario/skygear-server/pkg/core/inject"
 	"github.com/skygeario/skygear-server/pkg/core/server"
@@ -27,9 +25,9 @@ type LoginHandlerFactory struct {
 	Dependency auth.DependencyMap
 }
 
-func (f LoginHandlerFactory) NewHandler(ctx context.Context, tenantConfig config.TenantConfiguration) handler.Handler {
+func (f LoginHandlerFactory) NewHandler(request *http.Request) handler.Handler {
 	h := &LoginHandler{}
-	inject.DefaultInject(h, f.Dependency, ctx, tenantConfig)
+	inject.DefaultInject(h, f.Dependency, request)
 	return handler.APIHandlerToHandler(h)
 }
 

--- a/pkg/auth/handler/me.go
+++ b/pkg/auth/handler/me.go
@@ -1,13 +1,11 @@
 package handler
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/skygeario/skygear-server/pkg/auth"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz/policy"
-	"github.com/skygeario/skygear-server/pkg/core/config"
 	"github.com/skygeario/skygear-server/pkg/core/handler"
 	"github.com/skygeario/skygear-server/pkg/core/inject"
 	"github.com/skygeario/skygear-server/pkg/core/server"
@@ -27,9 +25,9 @@ type MeHandlerFactory struct {
 	Dependency auth.DependencyMap
 }
 
-func (f MeHandlerFactory) NewHandler(ctx context.Context, tenantConfig config.TenantConfiguration) handler.Handler {
+func (f MeHandlerFactory) NewHandler(request *http.Request) handler.Handler {
 	h := &MeHandler{}
-	inject.DefaultInject(h, f.Dependency, ctx, tenantConfig)
+	inject.DefaultInject(h, f.Dependency, request)
 	return handler.APIHandlerToHandler(h)
 }
 

--- a/pkg/auth/handler/signup.go
+++ b/pkg/auth/handler/signup.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/skygeario/skygear-server/pkg/core/auth/authtoken"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz/policy"
-	"github.com/skygeario/skygear-server/pkg/core/config"
 	"github.com/skygeario/skygear-server/pkg/core/handler"
 	"github.com/skygeario/skygear-server/pkg/core/inject"
 	"github.com/skygeario/skygear-server/pkg/core/server"
@@ -37,9 +35,9 @@ type SignupHandlerFactory struct {
 	Dependency auth.DependencyMap
 }
 
-func (f SignupHandlerFactory) NewHandler(ctx context.Context, tenantConfig config.TenantConfiguration) handler.Handler {
+func (f SignupHandlerFactory) NewHandler(request *http.Request) handler.Handler {
 	h := &SignupHandler{}
-	inject.DefaultInject(h, f.Dependency, ctx, tenantConfig)
+	inject.DefaultInject(h, f.Dependency, request)
 	return handler.APIHandlerToHandler(h)
 }
 

--- a/pkg/auth/inject.go
+++ b/pkg/auth/inject.go
@@ -43,10 +43,10 @@ func (m DependencyMap) Provide(dependencyName string, r *http.Request) interface
 		return password.NewProvider(
 			db.NewSQLBuilder("auth", tConfig.AppName),
 			db.NewSQLExecutor(r.Context(), "postgres", tConfig.DBConnectionStr),
-			logging.CreateLogger(r.Context(), "provider_password"),
+			logging.CreateLogger(r, "provider_password"),
 		)
 	case "HandlerLogger":
-		return logging.CreateLogger(r.Context(), "handler")
+		return logging.CreateLogger(r, "handler")
 	default:
 		return nil
 	}

--- a/pkg/auth/inject.go
+++ b/pkg/auth/inject.go
@@ -8,8 +8,8 @@ import (
 	coreAuth "github.com/skygeario/skygear-server/pkg/core/auth"
 	"github.com/skygeario/skygear-server/pkg/core/config"
 	"github.com/skygeario/skygear-server/pkg/core/db"
+	"github.com/skygeario/skygear-server/pkg/core/logging"
 	"github.com/skygeario/skygear-server/pkg/server/audit"
-	"github.com/skygeario/skygear-server/pkg/server/logging"
 )
 
 type DependencyMap struct{}
@@ -42,6 +42,8 @@ func (m DependencyMap) Provide(dependencyName string, ctx context.Context, tConf
 			db.NewSQLExecutor(ctx, "postgres", tConfig.DBConnectionStr),
 			logging.CreateLogger(ctx, "provider_password"),
 		)
+	case "HandlerLogger":
+		return logging.CreateLogger(ctx, "handler")
 	default:
 		return nil
 	}

--- a/pkg/core/handler/factory.go
+++ b/pkg/core/handler/factory.go
@@ -1,11 +1,9 @@
 package handler
 
 import (
-	"context"
-
-	"github.com/skygeario/skygear-server/pkg/core/config"
+	"net/http"
 )
 
 type Factory interface {
-	NewHandler(context.Context, config.TenantConfiguration) Handler
+	NewHandler(request *http.Request) Handler
 }

--- a/pkg/core/inject/inject.go
+++ b/pkg/core/inject/inject.go
@@ -1,30 +1,26 @@
 package inject
 
 import (
-	"context"
+	"net/http"
 	"reflect"
-
-	"github.com/skygeario/skygear-server/pkg/core/config"
 )
 
 type Map interface {
-	Provide(name string, ctx context.Context, configuration config.TenantConfiguration) interface{}
+	Provide(name string, request *http.Request) interface{}
 }
 
 func DefaultInject(
 	i interface{},
 	dependencyMap Map,
-	ctx context.Context,
-	configuration config.TenantConfiguration,
+	request *http.Request,
 ) {
-	injectDependency(i, dependencyMap, ctx, configuration)
+	injectDependency(i, dependencyMap, request)
 }
 
 func injectDependency(
 	i interface{},
 	dependencyMap Map,
-	ctx context.Context,
-	configuration config.TenantConfiguration,
+	request *http.Request,
 ) {
 	t := reflect.TypeOf(i).Elem()
 	v := reflect.ValueOf(i).Elem()
@@ -37,7 +33,7 @@ func injectDependency(
 		}
 
 		field := v.Field(i)
-		dependency := dependencyMap.Provide(dependencyName, ctx, configuration)
+		dependency := dependencyMap.Provide(dependencyName, request)
 		field.Set(reflect.ValueOf(dependency))
 	}
 }

--- a/pkg/core/logging/logging.go
+++ b/pkg/core/logging/logging.go
@@ -1,14 +1,103 @@
+// Copyright 2015-present Oursky Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package logging
 
 import (
+	"context"
+	"sync"
+
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	loggers                map[string]*logrus.Logger
+	lock                   sync.Mutex
+	configureLoggerHandler func(string, *logrus.Logger)
+)
 
-// CreateLogger create log entry for logging
-func CreateLogger(module string) *logrus.Entry {
-	logger := logrus.New()
-	// For debug use
-	// logger.SetLevel(logrus.DebugLevel)
-	return logger.WithField("module", module)
+func init() {
+	loggers = map[string]*logrus.Logger{}
+	loggers[""] = logrus.StandardLogger()
+}
+
+func SetConfigureLoggerHandler(handler func(string, *logrus.Logger)) {
+	configureLoggerHandler = handler
+}
+
+func Logger(name string) *logrus.Logger {
+	lock.Lock()
+	defer lock.Unlock()
+
+	logger, ok := loggers[name]
+	if !ok {
+		logger = logrus.New()
+
+		if logger == nil {
+			panic("logrus.New() returns nil")
+		}
+
+		handler := configureLoggerHandler
+		if handler != nil {
+			handler(name, logger)
+		}
+
+		loggers[name] = logger
+	}
+
+	return logger
+}
+
+func Loggers() map[string]*logrus.Logger {
+	lock.Lock()
+	defer lock.Unlock()
+
+	ret := map[string]*logrus.Logger{}
+	for loggerName, logger := range loggers {
+		ret[loggerName] = logger
+	}
+	return ret
+}
+
+func LoggerEntry(name string) *logrus.Entry {
+	return LoggerEntryWithTag(name, name)
+}
+
+func LoggerEntryWithTag(name string, tag string) *logrus.Entry {
+	logger := Logger(name)
+	fields := logrus.Fields{}
+	if name != "" {
+		fields["logger"] = name
+	}
+	if tag != "" {
+		fields["tag"] = tag
+	}
+	fields["process"] = "server"
+	return logger.WithFields(fields)
+}
+
+func CreateLogger(ctx context.Context, logger string) *logrus.Entry {
+	var requestTag string
+	fields := logrus.Fields{}
+	if ctx != nil {
+		if tag, ok := ctx.Value("RequestTag").(string); ok {
+			requestTag = tag
+		}
+
+		if requestID, ok := ctx.Value("RequestID").(string); ok {
+			fields["request_id"] = requestID
+		}
+	}
+	return LoggerEntryWithTag(logger, requestTag).WithFields(fields)
 }

--- a/pkg/core/logging/logging.go
+++ b/pkg/core/logging/logging.go
@@ -25,6 +25,7 @@ var (
 	loggers                map[string]*logrus.Logger
 	lock                   sync.Mutex
 	configureLoggerHandler func(string, *logrus.Logger)
+	gearModule                 string
 )
 
 func init() {
@@ -34,6 +35,10 @@ func init() {
 
 func SetConfigureLoggerHandler(handler func(string, *logrus.Logger)) {
 	configureLoggerHandler = handler
+}
+
+func SetModule(module string) {
+	gearModule = module
 }
 
 func Logger(name string) *logrus.Logger {
@@ -83,7 +88,9 @@ func LoggerEntryWithTag(name string, tag string) *logrus.Entry {
 	if tag != "" {
 		fields["tag"] = tag
 	}
-	fields["process"] = "server"
+	if gearModule != "" {
+		fields["module"] = gearModule
+	}
 	return logger.WithFields(fields)
 }
 

--- a/pkg/core/logging/logging.go
+++ b/pkg/core/logging/logging.go
@@ -15,7 +15,7 @@
 package logging
 
 import (
-	"context"
+	"net/http"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -94,17 +94,10 @@ func LoggerEntryWithTag(name string, tag string) *logrus.Entry {
 	return logger.WithFields(fields)
 }
 
-func CreateLogger(ctx context.Context, logger string) *logrus.Entry {
-	var requestTag string
+func CreateLogger(r *http.Request, logger string) *logrus.Entry {
 	fields := logrus.Fields{}
-	if ctx != nil {
-		if tag, ok := ctx.Value("RequestTag").(string); ok {
-			requestTag = tag
-		}
-
-		if requestID, ok := ctx.Value("RequestID").(string); ok {
-			fields["request_id"] = requestID
-		}
+	if requestID := r.Header.Get("X-Skygear-Request-ID"); requestID != "" {
+		fields["request_id"] = requestID
 	}
-	return LoggerEntryWithTag(logger, requestTag).WithFields(fields)
+	return LoggerEntry(logger).WithFields(fields)
 }

--- a/pkg/core/logging/logging_test.go
+++ b/pkg/core/logging/logging_test.go
@@ -1,0 +1,56 @@
+// Copyright 2015-present Oursky Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestLogger(t *testing.T) {
+	Convey("loggers", t, func() {
+		defer func() {
+			loggers = map[string]*logrus.Logger{
+				"": logrus.StandardLogger(),
+			}
+		}()
+
+		Convey("get new logger", func() {
+			logger := Logger("hello")
+			So(logger, ShouldNotBeNil)
+			So(logger, ShouldResemble, loggers["hello"])
+		})
+
+		Convey("same logger for same name", func() {
+			So(Logger("hello"), ShouldPointTo, Logger("hello"))
+		})
+
+		Convey("get root logger", func() {
+			So(Logger(""), ShouldPointTo, logrus.StandardLogger())
+		})
+
+		Convey("get loggers", func() {
+			Logger("hello")
+			Logger("world")
+
+			returnedLoggers := Loggers()
+			So(returnedLoggers, ShouldContainKey, "hello")
+			So(returnedLoggers, ShouldContainKey, "world")
+		})
+	})
+}

--- a/pkg/core/logging/text_formatter.go
+++ b/pkg/core/logging/text_formatter.go
@@ -1,0 +1,217 @@
+// This file is adapted from
+// https://github.com/sirupsen/logrus/blob/778f2e7/text_formatter.go
+
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	krtext "github.com/kr/text"
+	"github.com/sirupsen/logrus"
+)
+
+const defaultTimestampFormat = time.RFC3339
+
+const (
+	nocolor = 0
+	red     = 31
+	green   = 32
+	yellow  = 33
+	blue    = 36
+	gray    = 37
+)
+
+var (
+	baseTimestamp time.Time
+	emptyFieldMap logrus.FieldMap
+)
+
+func init() {
+	baseTimestamp = time.Now()
+}
+
+type ValueFormatter interface {
+	Print(b *bytes.Buffer)
+}
+
+// TextFormatter formats logs into text
+type TextFormatter struct {
+	// Set to true to bypass checking for a TTY before outputting colors.
+	ForceColors bool
+
+	// Force disabling colors.
+	DisableColors bool
+
+	// Disable timestamp logging. useful when output is redirected to logging
+	// system that already adds timestamps.
+	DisableTimestamp bool
+
+	// Enable logging the full timestamp when a TTY is attached instead of just
+	// the time passed since beginning of execution.
+	FullTimestamp bool
+
+	// TimestampFormat to use for display when a full timestamp is printed
+	TimestampFormat string
+
+	// The fields are sorted by default for a consistent output. For applications
+	// that log extremely frequently and don't use the JSON formatter this may not
+	// be desired.
+	DisableSorting bool
+
+	// Disables the truncation of the level text to 4 characters.
+	DisableLevelTruncation bool
+
+	// QuoteEmptyFields will wrap empty fields in quotes if true
+	QuoteEmptyFields bool
+
+	// Whether the logger's out is to a terminal
+	isTerminal bool
+
+	sync.Once
+}
+
+func (f *TextFormatter) init(entry *logrus.Entry) {
+	//if entry.Logger != nil {
+	//	f.isTerminal = checkIfTerminal(entry.Logger.Out)
+	//}
+}
+
+// Format renders a single log entry
+func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	var b *bytes.Buffer
+	keys := []string{}
+	formattedKeys := []string{}
+	for k, v := range entry.Data {
+		if _, ok := v.(ValueFormatter); ok {
+			formattedKeys = append(formattedKeys, k)
+			continue
+		}
+		keys = append(keys, k)
+	}
+
+	if !f.DisableSorting {
+		sort.Strings(keys)
+	}
+	if entry.Buffer != nil {
+		b = entry.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
+
+	//prefixFieldClashes(entry.Data, emptyFieldMap)
+
+	f.Do(func() { f.init(entry) })
+
+	isColored := (f.ForceColors || f.isTerminal) && !f.DisableColors
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = defaultTimestampFormat
+	}
+	if isColored {
+		f.printColored(b, entry, keys, timestampFormat)
+	} else {
+		if !f.DisableTimestamp {
+			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
+		}
+		f.appendKeyValue(b, "level", entry.Level.String())
+		if entry.Message != "" {
+			f.appendKeyValue(b, "msg", entry.Message)
+		}
+		for _, key := range keys {
+			f.appendKeyValue(b, key, entry.Data[key])
+		}
+	}
+
+	b.WriteByte('\n')
+
+	for _, key := range formattedKeys {
+		if v, ok := entry.Data[key].(ValueFormatter); ok {
+			vb := &bytes.Buffer{}
+			v.Print(vb)
+
+			b.WriteString(key)
+			b.WriteByte(':')
+			b.WriteByte('\n')
+			b.WriteString(krtext.Indent(vb.String(), "    "))
+			b.WriteByte('\n')
+		}
+	}
+
+	return b.Bytes(), nil
+}
+
+func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys []string, timestampFormat string) {
+	var levelColor int
+	switch entry.Level {
+	case logrus.DebugLevel:
+		levelColor = gray
+	case logrus.WarnLevel:
+		levelColor = yellow
+	case logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel:
+		levelColor = red
+	default:
+		levelColor = blue
+	}
+
+	levelText := strings.ToUpper(entry.Level.String())
+	if !f.DisableLevelTruncation {
+		levelText = levelText[0:4]
+	}
+
+	if f.DisableTimestamp {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %-44s ", levelColor, levelText, entry.Message)
+	} else if !f.FullTimestamp {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ", levelColor, levelText, int(entry.Time.Sub(baseTimestamp)/time.Second), entry.Message)
+	} else {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, entry.Time.Format(timestampFormat), entry.Message)
+	}
+	for _, k := range keys {
+		v := entry.Data[k]
+		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=", levelColor, k)
+		f.appendValue(b, v)
+	}
+}
+
+// nolint: gocyclo
+func (f *TextFormatter) needsQuoting(text string) bool {
+	if f.QuoteEmptyFields && len(text) == 0 {
+		return true
+	}
+	for _, ch := range text {
+		if !((ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' || ch == '.' || ch == '_' || ch == '/' || ch == '@' || ch == '^' || ch == '+') {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}) {
+	if b.Len() > 0 {
+		b.WriteByte(' ')
+	}
+	b.WriteString(key)
+	b.WriteByte('=')
+	f.appendValue(b, value)
+}
+
+func (f *TextFormatter) appendValue(b *bytes.Buffer, value interface{}) {
+	stringVal, ok := value.(string)
+	if !ok {
+		stringVal = fmt.Sprint(value)
+	}
+
+	if !f.needsQuoting(stringVal) {
+		b.WriteString(stringVal)
+	} else {
+		b.WriteString(fmt.Sprintf("%q", stringVal))
+	}
+}

--- a/pkg/core/logging/value_formatters.go
+++ b/pkg/core/logging/value_formatters.go
@@ -1,0 +1,28 @@
+// Copyright 2015-present Oursky Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"bytes"
+)
+
+// StringValueFormatter is a string that provides value formatting for logging
+// multiline string value.
+type StringValueFormatter string
+
+// Print prints the string value to bytes buffer.
+func (f StringValueFormatter) Print(b *bytes.Buffer) {
+	b.WriteString(string(f))
+}

--- a/pkg/core/middleware/requestid.go
+++ b/pkg/core/middleware/requestid.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/skygeario/skygear-server/pkg/server/uuid"
@@ -13,10 +12,8 @@ type RequestIDMiddleware struct {}
 func (m RequestIDMiddleware) Handle(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestID := uuid.New()
-		newContext := context.WithValue(r.Context(), "RequestID", requestID)
-		r = r.WithContext(newContext)
-
-		w.Header().Set("X-Skygear-Request-Id", requestID)
+		r.Header.Set("X-Skygear-Request-ID", requestID)
+		w.Header().Set("X-Skygear-Request-ID", requestID)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/pkg/core/middleware/requestid.go
+++ b/pkg/core/middleware/requestid.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/skygeario/skygear-server/pkg/server/uuid"
+)
+
+// RequestIDMiddleware add random request id to request context
+type RequestIDMiddleware struct {}
+
+func (m RequestIDMiddleware) Handle(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := uuid.New()
+		newContext := context.WithValue(r.Context(), "RequestID", requestID)
+		r = r.WithContext(newContext)
+
+		w.Header().Set("X-Skygear-Request-Id", requestID)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/core/server/server.go
+++ b/pkg/core/server/server.go
@@ -47,7 +47,7 @@ func (s *Server) Handle(path string, hf handler.Factory) *mux.Route {
 	return s.router.NewRoute().Path(path).Handler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		configuration := config.GetTenantConfig(r)
 
-		h := hf.NewHandler(r.Context(), configuration)
+		h := hf.NewHandler(r)
 
 		resolver := s.authContextResolverFactory.NewResolver(r.Context(), configuration)
 		ctx, _ := resolver.Resolve(r)

--- a/pkg/gateway/config/config.go
+++ b/pkg/gateway/config/config.go
@@ -22,7 +22,7 @@ type Configuration struct {
 
 // ReadFromEnv reads from environment variable and update the configuration.
 func (c *Configuration) ReadFromEnv() error {
-	logger := logging.CreateLogger("gateway")
+	logger := logging.LoggerEntry("gateway")
 	if err := godotenv.Load(); err != nil {
 		logger.WithError(err).Info(
 			"Error in loading .env file, continue without .env")

--- a/pkg/gateway/db/pq/app.go
+++ b/pkg/gateway/db/pq/app.go
@@ -18,7 +18,7 @@ var ErrConfigNotFound = errors.New("Tenant config not found")
 
 
 func (s *store) GetAppByDomain(domain string, app *model.App) error {
-	logger := logging.CreateLogger("gateway")
+	logger := logging.LoggerEntry("gateway")
 	builder := psql.Select("app.id", "app.name", "app.config_id", "app.plan_id").
 		From(s.tableName("app")).
 		Join(s.tableName("domain") + " ON app.id = domain.app_id").

--- a/pkg/gateway/db/pq/store_exec.go
+++ b/pkg/gateway/db/pq/store_exec.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *store) QueryRowx(query string, args ...interface{}) (row *sqlx.Row) {
-	logger := logging.CreateLogger("gateway")
+	logger := logging.LoggerEntry("gateway")
 	row = s.DB.QueryRowxContext(s.context, query, args...)
 	logger.WithFields(logrus.Fields{
 		"sql":            query,

--- a/pkg/gateway/db/pq/types.go
+++ b/pkg/gateway/db/pq/types.go
@@ -36,7 +36,7 @@ func (v *tenantConfigurationValue) Scan(value interface{}) error {
 
 	b, ok := value.([]byte)
 	if !ok {
-		logger := logging.CreateLogger("gateway")
+		logger := logging.LoggerEntry("gateway")
 		logger.Errorf("Unsupported Scan pair: %T -> %T", value, v.TenantConfiguration)
 	}
 

--- a/pkg/gateway/provider/config.go
+++ b/pkg/gateway/provider/config.go
@@ -18,7 +18,7 @@ type GatewayTenantConfigurationProvider struct {
 
 // ProvideConfig function query the tenant config from db by request
 func (p GatewayTenantConfigurationProvider) ProvideConfig(r *http.Request) (config.TenantConfiguration, error) {
-	logger := logging.CreateLogger("gateway")
+	logger := logging.LoggerEntry("gateway")
 
 	host := r.Host
 	app := model.App{}


### PR DESCRIPTION
Try to bring back logging functionality to next, what I did in this pr.

- Move logging from v1 to next
- Add middleware that add request id to context
- Add `HandlerLogger` dependency

Question: The request id middleware is copied from v1, which will create request id and update the context. As I remember, we had discussion about the middleware should only update request header in next? So the old middleware implement may violate the rule? Or it is acceptable in this case?