### PR TITLE
next: Fix api handler bypassed authz policy

### DIFF
--- a/pkg/auth/handler/disable.go
+++ b/pkg/auth/handler/disable.go
@@ -10,6 +10,7 @@ import (
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz/policy"
 	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/core/inject"
 	"github.com/skygeario/skygear-server/pkg/core/server"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
@@ -88,7 +89,7 @@ func (h SetDisableHandler) DecodeRequest(request *http.Request) (handler.Request
 }
 
 // Handle function handle set disabled request
-func (h SetDisableHandler) Handle(req interface{}, ctx handler.AuthContext) (resp interface{}, err error) {
+func (h SetDisableHandler) Handle(req interface{}, ctx context.AuthContext) (resp interface{}, err error) {
 	p := req.(setDisableUserPayload)
 
 	authinfo := authinfo.AuthInfo{}

--- a/pkg/auth/handler/disable.go
+++ b/pkg/auth/handler/disable.go
@@ -1,9 +1,9 @@
 package handler
 
 import (
-	"time"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/skygeario/skygear-server/pkg/auth"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authinfo"
@@ -12,8 +12,8 @@ import (
 	"github.com/skygeario/skygear-server/pkg/core/handler"
 	"github.com/skygeario/skygear-server/pkg/core/inject"
 	"github.com/skygeario/skygear-server/pkg/core/server"
-	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
+	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )
 
 // AttachSetDisableHandler attaches SetDisableHandler to server
@@ -39,6 +39,16 @@ func (f SetDisableHandlerFactory) NewHandler(request *http.Request) handler.Hand
 	return handler.APIHandlerToHandler(h)
 }
 
+// ProvideAuthzPolicy provides authorization policy of handler
+func (f SetDisableHandlerFactory) ProvideAuthzPolicy() authz.Policy {
+	// FIXME: Admin only after adding admin role
+	return policy.AllOf(
+		authz.PolicyFunc(policy.DenyNoAccessKey),
+		authz.PolicyFunc(policy.RequireAuthenticated),
+		authz.PolicyFunc(policy.DenyDisabledUser),
+	)
+}
+
 type setDisableUserPayload struct {
 	AuthInfoID   string `json:"auth_id"`
 	Disabled     bool   `json:"disabled"`
@@ -55,18 +65,8 @@ func (payload setDisableUserPayload) Validate() error {
 }
 
 // SetDisableHandler handles set disable request
-type SetDisableHandler struct{
-	AuthInfoStore        authinfo.Store             `dependency:"AuthInfoStore"`
-}
-
-// ProvideAuthzPolicy provides authorization policy of handler
-func (h SetDisableHandler) ProvideAuthzPolicy() authz.Policy {
-	// FIXME: Admin only after adding admin role
-	return policy.AllOf(
-		authz.PolicyFunc(policy.DenyNoAccessKey),
-		authz.PolicyFunc(policy.RequireAuthenticated),
-		authz.PolicyFunc(policy.DenyDisabledUser),
-	)
+type SetDisableHandler struct {
+	AuthInfoStore authinfo.Store `dependency:"AuthInfoStore"`
 }
 
 // DecodeRequest decode request payload

--- a/pkg/auth/handler/login.go
+++ b/pkg/auth/handler/login.go
@@ -31,12 +31,12 @@ func (f LoginHandlerFactory) NewHandler(request *http.Request) handler.Handler {
 	return handler.APIHandlerToHandler(h)
 }
 
-// LoginHandler handles login request
-type LoginHandler struct{}
-
-func (h LoginHandler) ProvideAuthzPolicy() authz.Policy {
+func (f LoginHandlerFactory) ProvideAuthzPolicy() authz.Policy {
 	return authz.PolicyFunc(policy.DenyNoAccessKey)
 }
+
+// LoginHandler handles login request
+type LoginHandler struct{}
 
 func (h LoginHandler) DecodeRequest(request *http.Request) (payload handler.RequestPayload, err error) {
 	payload = handler.EmptyRequestPayload{}

--- a/pkg/auth/handler/login.go
+++ b/pkg/auth/handler/login.go
@@ -7,6 +7,7 @@ import (
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz/policy"
 	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/core/inject"
 	"github.com/skygeario/skygear-server/pkg/core/server"
 )
@@ -43,7 +44,7 @@ func (h LoginHandler) DecodeRequest(request *http.Request) (payload handler.Requ
 	return
 }
 
-func (h LoginHandler) Handle(req interface{}, ctx handler.AuthContext) (resp interface{}, err error) {
+func (h LoginHandler) Handle(req interface{}, ctx context.AuthContext) (resp interface{}, err error) {
 	resp = map[string]interface{}{"user": "user:abc"}
 	return
 }

--- a/pkg/auth/handler/me.go
+++ b/pkg/auth/handler/me.go
@@ -31,16 +31,16 @@ func (f MeHandlerFactory) NewHandler(request *http.Request) handler.Handler {
 	return handler.APIHandlerToHandler(h)
 }
 
-// MeHandler handles me request
-type MeHandler struct{}
-
-func (h MeHandler) ProvideAuthzPolicy() authz.Policy {
+func (f MeHandlerFactory) ProvideAuthzPolicy() authz.Policy {
 	return policy.AllOf(
 		authz.PolicyFunc(policy.DenyNoAccessKey),
 		authz.PolicyFunc(policy.RequireAuthenticated),
 		authz.PolicyFunc(policy.DenyDisabledUser),
 	)
 }
+
+// MeHandler handles me request
+type MeHandler struct{}
 
 func (h MeHandler) DecodeRequest(request *http.Request) (payload handler.RequestPayload, err error) {
 	payload = handler.EmptyRequestPayload{}

--- a/pkg/auth/handler/me.go
+++ b/pkg/auth/handler/me.go
@@ -7,6 +7,7 @@ import (
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz/policy"
 	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/core/inject"
 	"github.com/skygeario/skygear-server/pkg/core/server"
 )
@@ -47,7 +48,7 @@ func (h MeHandler) DecodeRequest(request *http.Request) (payload handler.Request
 	return
 }
 
-func (h MeHandler) Handle(req interface{}, ctx handler.AuthContext) (resp interface{}, err error) {
+func (h MeHandler) Handle(req interface{}, ctx context.AuthContext) (resp interface{}, err error) {
 	resp = ctx.AuthInfo
 	return
 }

--- a/pkg/auth/handler/signup.go
+++ b/pkg/auth/handler/signup.go
@@ -41,6 +41,10 @@ func (f SignupHandlerFactory) NewHandler(request *http.Request) handler.Handler 
 	return handler.APIHandlerToHandler(h)
 }
 
+func (f SignupHandlerFactory) ProvideAuthzPolicy() authz.Policy {
+	return authz.PolicyFunc(policy.DenyNoAccessKey)
+}
+
 type SignupRequestPayload struct {
 	AuthData         map[string]interface{} `json:"auth_data"`
 	Password         string                 `json:"password"`
@@ -69,10 +73,6 @@ type SignupHandler struct {
 	TokenStore           authtoken.Store             `dependency:"TokenStore"`
 	AuthInfoStore        authinfo.Store              `dependency:"AuthInfoStore"`
 	PasswordAuthProvider password.Provider           `dependency:"PasswordAuthProvider"`
-}
-
-func (h SignupHandler) ProvideAuthzPolicy() authz.Policy {
-	return authz.PolicyFunc(policy.DenyNoAccessKey)
 }
 
 func (h SignupHandler) DecodeRequest(request *http.Request) (handler.RequestPayload, error) {

--- a/pkg/auth/handler/signup.go
+++ b/pkg/auth/handler/signup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz/policy"
 	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/core/inject"
 	"github.com/skygeario/skygear-server/pkg/core/server"
 	"github.com/skygeario/skygear-server/pkg/server/audit"
@@ -81,7 +82,7 @@ func (h SignupHandler) DecodeRequest(request *http.Request) (handler.RequestPayl
 	return payload, err
 }
 
-func (h SignupHandler) Handle(req interface{}, _ handler.AuthContext) (resp interface{}, err error) {
+func (h SignupHandler) Handle(req interface{}, _ context.AuthContext) (resp interface{}, err error) {
 	payload := req.(SignupRequestPayload)
 
 	if valid := h.AuthDataChecker.IsValid(payload.AuthData); !valid {
@@ -98,7 +99,7 @@ func (h SignupHandler) Handle(req interface{}, _ handler.AuthContext) (resp inte
 		return
 	}
 
-	authContext := handler.AuthContext{}
+	authContext := context.AuthContext{}
 
 	now := timeNow()
 	info := authinfo.NewAuthInfo()

--- a/pkg/auth/response/response.go
+++ b/pkg/auth/response/response.go
@@ -17,7 +17,7 @@ package response
 import (
 	"time"
 
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 	"github.com/skygeario/skygear-server/pkg/server/skydb/skyconv"
 	"github.com/skygeario/skygear-server/pkg/server/uuid"
@@ -38,7 +38,7 @@ type AuthResponse struct {
 	LastSeenAt  *time.Time          `json:"last_seen_at,omitempty"`
 }
 
-func NewAuthResponse(ctx handler.AuthContext, user skydb.Record, accessToken string) AuthResponse {
+func NewAuthResponse(ctx context.AuthContext, user skydb.Record, accessToken string) AuthResponse {
 	var jsonUser *skyconv.JSONRecord
 	var lastLoginAt *time.Time
 

--- a/pkg/core/auth/authn/authn.go
+++ b/pkg/core/auth/authn/authn.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/skygeario/skygear-server/pkg/core/config"
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	skyContext "github.com/skygeario/skygear-server/pkg/core/handler/context"
 )
 
 type AuthContextResolverFactory interface {
@@ -13,5 +13,5 @@ type AuthContextResolverFactory interface {
 }
 
 type AuthContextResolver interface {
-	Resolve(*http.Request) (handler.AuthContext, error)
+	Resolve(*http.Request) (skyContext.AuthContext, error)
 }

--- a/pkg/core/auth/authn/resolver/default.go
+++ b/pkg/core/auth/authn/resolver/default.go
@@ -9,7 +9,7 @@ import (
 	"github.com/skygeario/skygear-server/pkg/core/auth/authn"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authtoken"
 	"github.com/skygeario/skygear-server/pkg/core/config"
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	skyContext "github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/core/model"
 )
 
@@ -28,7 +28,7 @@ type DefaultAuthContextResolver struct {
 	AuthInfoStore authinfo.Store
 }
 
-func (r DefaultAuthContextResolver) Resolve(req *http.Request) (ctx handler.AuthContext, err error) {
+func (r DefaultAuthContextResolver) Resolve(req *http.Request) (ctx skyContext.AuthContext, err error) {
 	keyType := model.GetAccessKeyType(req)
 
 	var resolver authn.AuthContextResolver

--- a/pkg/core/auth/authn/resolver/masterkey.go
+++ b/pkg/core/auth/authn/resolver/masterkey.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/skygeario/skygear-server/pkg/core/auth/authinfo"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authtoken"
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	skyContext "github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/core/model"
 	"github.com/skygeario/skygear-server/pkg/server/skydb"
 )
@@ -15,7 +15,7 @@ type masterkeyAuthContextResolver struct {
 	AuthInfoStore authinfo.Store
 }
 
-func (r masterkeyAuthContextResolver) Resolve(req *http.Request) (ctx handler.AuthContext, err error) {
+func (r masterkeyAuthContextResolver) Resolve(req *http.Request) (ctx skyContext.AuthContext, err error) {
 	tokenStr := model.GetAccessToken(req)
 	token := &authtoken.Token{}
 	r.TokenStore.Get(tokenStr, token)

--- a/pkg/core/auth/authn/resolver/non_masterkey.go
+++ b/pkg/core/auth/authn/resolver/non_masterkey.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/skygeario/skygear-server/pkg/core/auth/authinfo"
 	"github.com/skygeario/skygear-server/pkg/core/auth/authtoken"
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	skyContext "github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/core/model"
 )
 
@@ -14,7 +14,7 @@ type nonMasterkeyAuthContextResolver struct {
 	AuthInfoStore authinfo.Store
 }
 
-func (r nonMasterkeyAuthContextResolver) Resolve(req *http.Request) (ctx handler.AuthContext, err error) {
+func (r nonMasterkeyAuthContextResolver) Resolve(req *http.Request) (ctx skyContext.AuthContext, err error) {
 	tokenStr := model.GetAccessToken(req)
 
 	token := &authtoken.Token{}

--- a/pkg/core/auth/authz/authz.go
+++ b/pkg/core/auth/authz/authz.go
@@ -3,7 +3,7 @@ package authz
 import (
 	"net/http"
 
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 )
 
 type PolicyProvider interface {
@@ -11,11 +11,11 @@ type PolicyProvider interface {
 }
 
 type Policy interface {
-	IsAllowed(r *http.Request, ctx handler.AuthContext) error
+	IsAllowed(r *http.Request, ctx context.AuthContext) error
 }
 
-type PolicyFunc func(r *http.Request, ctx handler.AuthContext) error
+type PolicyFunc func(r *http.Request, ctx context.AuthContext) error
 
-func (f PolicyFunc) IsAllowed(r *http.Request, ctx handler.AuthContext) error {
+func (f PolicyFunc) IsAllowed(r *http.Request, ctx context.AuthContext) error {
 	return f(r, ctx)
 }

--- a/pkg/core/auth/authz/policy/accesskey.go
+++ b/pkg/core/auth/authz/policy/accesskey.go
@@ -3,12 +3,12 @@ package policy
 import (
 	"net/http"
 
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/core/model"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )
 
-func DenyNoAccessKey(r *http.Request, ctx handler.AuthContext) error {
+func DenyNoAccessKey(r *http.Request, ctx context.AuthContext) error {
 	keyType := ctx.AccessKeyType
 	if keyType == model.NoAccessKey {
 		return skyerr.NewError(skyerr.AccessKeyNotAccepted, "api key required")
@@ -17,7 +17,7 @@ func DenyNoAccessKey(r *http.Request, ctx handler.AuthContext) error {
 	return nil
 }
 
-func RequireMasterKey(r *http.Request, ctx handler.AuthContext) error {
+func RequireMasterKey(r *http.Request, ctx context.AuthContext) error {
 	keyType := ctx.AccessKeyType
 	if keyType != model.MasterAccessKey {
 		return skyerr.NewError(skyerr.AccessKeyNotAccepted, "master key required")

--- a/pkg/core/auth/authz/policy/authinfo.go
+++ b/pkg/core/auth/authz/policy/authinfo.go
@@ -4,11 +4,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )
 
-func RequireAuthenticated(r *http.Request, ctx handler.AuthContext) error {
+func RequireAuthenticated(r *http.Request, ctx context.AuthContext) error {
 	if ctx.AuthInfo == nil {
 		return skyerr.NewError(skyerr.NotAuthenticated, "require authenticated user")
 	}

--- a/pkg/core/auth/authz/policy/compound.go
+++ b/pkg/core/auth/authz/policy/compound.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 )
 
 type All struct {
@@ -15,7 +15,7 @@ func AllOf(policies ...authz.Policy) authz.Policy {
 	return All{policies: policies}
 }
 
-func (p All) IsAllowed(r *http.Request, ctx handler.AuthContext) error {
+func (p All) IsAllowed(r *http.Request, ctx context.AuthContext) error {
 	for _, policy := range p.policies {
 		if err := policy.IsAllowed(r, ctx); err != nil {
 			return err

--- a/pkg/core/auth/authz/policy/disable.go
+++ b/pkg/core/auth/authz/policy/disable.go
@@ -3,11 +3,11 @@ package policy
 import (
 	"net/http"
 
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )
 
-func DenyDisabledUser(r *http.Request, ctx handler.AuthContext) error {
+func DenyDisabledUser(r *http.Request, ctx context.AuthContext) error {
 	if ctx.AuthInfo == nil {
 		return skyerr.NewError(skyerr.UnexpectedAuthInfoNotFound, "user authentication info not found")
 	}

--- a/pkg/core/auth/authz/policy/everybody.go
+++ b/pkg/core/auth/authz/policy/everybody.go
@@ -3,7 +3,7 @@ package policy
 import (
 	"net/http"
 
-	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )
 
@@ -11,7 +11,7 @@ type Everybody struct {
 	allow bool
 }
 
-func (p Everybody) IsAllowed(r *http.Request, ctx handler.AuthContext) error {
+func (p Everybody) IsAllowed(r *http.Request, ctx context.AuthContext) error {
 	if !p.allow {
 		// TODO:
 		// return proper error code

--- a/pkg/core/auth/authz/policy/role.go
+++ b/pkg/core/auth/authz/policy/role.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 
-	"github.com/skygeario/skygear-server/pkg/core/handler"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )
 
@@ -22,7 +22,7 @@ func NewDenyRole(role string) authz.Policy {
 	return Role{role: role, allow: false}
 }
 
-func (p Role) IsAllowed(r *http.Request, ctx handler.AuthContext) error {
+func (p Role) IsAllowed(r *http.Request, ctx context.AuthContext) error {
 	if ctx.AuthInfo == nil {
 		return skyerr.NewError(skyerr.UnexpectedAuthInfoNotFound, "user authentication info not found")
 	}

--- a/pkg/core/handler/api.go
+++ b/pkg/core/handler/api.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 	"github.com/skygeario/skygear-server/pkg/server/skyerr"
 )
 
 type APIHandler interface {
 	DecodeRequest(request *http.Request) (RequestPayload, error)
-	Handle(requestPayload interface{}, ctx AuthContext) (interface{}, error)
+	Handle(requestPayload interface{}, ctx context.AuthContext) (interface{}, error)
 }
 
 type APIResponse struct {
@@ -18,7 +19,7 @@ type APIResponse struct {
 }
 
 func APIHandlerToHandler(apiHandler APIHandler) Handler {
-	return HandlerFunc(func(rw http.ResponseWriter, r *http.Request, ctx AuthContext) {
+	return HandlerFunc(func(rw http.ResponseWriter, r *http.Request, ctx context.AuthContext) {
 		payload, err := apiHandler.DecodeRequest(r)
 		if err != nil {
 			// TODO:

--- a/pkg/core/handler/context/context.go
+++ b/pkg/core/handler/context/context.go
@@ -1,0 +1,13 @@
+package context
+
+import (
+	"github.com/skygeario/skygear-server/pkg/core/auth/authinfo"
+	"github.com/skygeario/skygear-server/pkg/core/auth/authtoken"
+	"github.com/skygeario/skygear-server/pkg/core/model"
+)
+
+type AuthContext struct {
+	AccessKeyType model.KeyType
+	AuthInfo      *authinfo.AuthInfo
+	Token         *authtoken.Token
+}

--- a/pkg/core/handler/factory.go
+++ b/pkg/core/handler/factory.go
@@ -2,8 +2,11 @@ package handler
 
 import (
 	"net/http"
+
+	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
 )
 
 type Factory interface {
+	authz.PolicyProvider
 	NewHandler(request *http.Request) Handler
 }

--- a/pkg/core/handler/handler.go
+++ b/pkg/core/handler/handler.go
@@ -3,23 +3,15 @@ package handler
 import (
 	"net/http"
 
-	"github.com/skygeario/skygear-server/pkg/core/auth/authinfo"
-	"github.com/skygeario/skygear-server/pkg/core/auth/authtoken"
-	"github.com/skygeario/skygear-server/pkg/core/model"
+	"github.com/skygeario/skygear-server/pkg/core/handler/context"
 )
 
-type AuthContext struct {
-	AccessKeyType model.KeyType
-	AuthInfo      *authinfo.AuthInfo
-	Token         *authtoken.Token
-}
-
 type Handler interface {
-	ServeHTTP(http.ResponseWriter, *http.Request, AuthContext)
+	ServeHTTP(http.ResponseWriter, *http.Request, context.AuthContext)
 }
 
-type HandlerFunc func(http.ResponseWriter, *http.Request, AuthContext)
+type HandlerFunc func(http.ResponseWriter, *http.Request, context.AuthContext)
 
-func (f HandlerFunc) ServeHTTP(rw http.ResponseWriter, r *http.Request, ctx AuthContext) {
+func (f HandlerFunc) ServeHTTP(rw http.ResponseWriter, r *http.Request, ctx context.AuthContext) {
 	f(rw, r, ctx)
 }

--- a/pkg/core/server/server.go
+++ b/pkg/core/server/server.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/skygeario/skygear-server/pkg/core/auth/authn"
-	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
 
 	"github.com/gorilla/mux"
 	"github.com/skygeario/skygear-server/pkg/core/config"
@@ -52,14 +51,12 @@ func (s *Server) Handle(path string, hf handler.Factory) *mux.Route {
 		resolver := s.authContextResolverFactory.NewResolver(r.Context(), configuration)
 		ctx, _ := resolver.Resolve(r)
 
-		if policyProvider, ok := hf.(authz.PolicyProvider); ok {
-			policy := policyProvider.ProvideAuthzPolicy()
-			if err := policy.IsAllowed(r, ctx); err != nil {
-				// TODO:
-				// handle error properly
-				http.Error(rw, err.Error(), http.StatusUnauthorized)
-				return
-			}
+		policy := hf.ProvideAuthzPolicy()
+		if err := policy.IsAllowed(r, ctx); err != nil {
+			// TODO:
+			// handle error properly
+			http.Error(rw, err.Error(), http.StatusUnauthorized)
+			return
 		}
 
 		h.ServeHTTP(rw, r, ctx)

--- a/pkg/core/server/server.go
+++ b/pkg/core/server/server.go
@@ -36,8 +36,8 @@ func NewServer(
 	}
 
 	return Server{
-		router:                     router,
-		Server:                     srv,
+		router: router,
+		Server: srv,
 		authContextResolverFactory: authContextResolverFactory,
 	}
 }
@@ -52,7 +52,7 @@ func (s *Server) Handle(path string, hf handler.Factory) *mux.Route {
 		resolver := s.authContextResolverFactory.NewResolver(r.Context(), configuration)
 		ctx, _ := resolver.Resolve(r)
 
-		if policyProvider, ok := h.(authz.PolicyProvider); ok {
+		if policyProvider, ok := hf.(authz.PolicyProvider); ok {
 			policy := policyProvider.ProvideAuthzPolicy()
 			if err := policy.IsAllowed(r, ctx); err != nil {
 				// TODO:


### PR DESCRIPTION
Move authz.PolicyProvider from handler to handler factory.

---

Update:

handler.Factory must implement authz.PolicyProvider, reason:

- Optional interface make debug hard, it's hard to trace if the policies are applied to one endpoint until test case or runtime.
- Authentication is mandatory already, so making authorisation mandatory seems also resonable.
- Adding `Allow everybody` policy is easy.
- Authorisation itself is stateless and lightweight, adding it to every handler should have very little performance hit.