### PR TITLE
next: get role

### DIFF
--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -57,6 +57,7 @@ func main() {
 	handler.AttachSetDisableHandler(&srv, authDependency)
 	handler.AttachRoleAssignHandler(&srv, authDependency)
 	handler.AttachResetPasswordHandler(&srv, authDependency)
+	handler.AttachGetRoleHandler(&srv, authDependency)
 
 	go func() {
 		log.Printf("Auth gear boot")

--- a/pkg/auth/handler/get_role.go
+++ b/pkg/auth/handler/get_role.go
@@ -1,0 +1,112 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/skygeario/skygear-server/pkg/auth"
+	"github.com/skygeario/skygear-server/pkg/core/auth/authinfo"
+	"github.com/skygeario/skygear-server/pkg/core/auth/authz"
+	"github.com/skygeario/skygear-server/pkg/core/auth/authz/policy"
+	"github.com/skygeario/skygear-server/pkg/core/db"
+	"github.com/skygeario/skygear-server/pkg/core/handler"
+	"github.com/skygeario/skygear-server/pkg/core/inject"
+	"github.com/skygeario/skygear-server/pkg/core/server"
+	"github.com/skygeario/skygear-server/pkg/server/skyerr"
+)
+
+func AttachGetRoleHandler(
+	server *server.Server,
+	authDependency auth.DependencyMap,
+) *server.Server {
+	server.Handle("/role/get", &GetRoleHandlerFactory{
+		authDependency,
+	}).Methods("POST")
+	return server
+}
+
+type GetRoleHandlerFactory struct {
+	Dependency auth.DependencyMap
+}
+
+func (f GetRoleHandlerFactory) NewHandler(request *http.Request) http.Handler {
+	h := &GetRoleHandler{}
+	inject.DefaultInject(h, f.Dependency, request)
+	return handler.APIHandlerToHandler(h, h.TxContext)
+}
+
+func (f GetRoleHandlerFactory) ProvideAuthzPolicy() authz.Policy {
+	return policy.AllOf(
+		// FIXME: this endpoint should hanlde request with master key or with access key
+		// Users can only get his own roles except that administrators can query roles
+		// of other users.
+		// This is temporary implementation to support admin user role only.
+		authz.PolicyFunc(policy.RequireMasterKey),
+		authz.PolicyFunc(policy.RequireAuthenticated),
+		authz.PolicyFunc(policy.DenyDisabledUser),
+	)
+}
+
+type GetRoleRequestPayload struct {
+	UserIDs []string `json:"users"`
+}
+
+func (p GetRoleRequestPayload) Validate() error {
+	return nil
+}
+
+// GetRoleHandler returns roles of users specified by user IDs. Users can only
+// get his own roles except that administrators can query roles of other users.
+//
+// curl \
+//   -X POST \
+//   -H "Content-Type: application/json" \
+//   -H "X-Skygear-Api-Key: MASTER_KEY" \
+//   -H "X-Skygear-Access-Token: ACCESS_TOKEN" \
+//   -d @- \
+//   http://localhost:3000/role/get \
+// <<EOF
+// {
+//     "users": [
+//        "user_id_1",
+//        "user_id_2",
+//     ]
+// }
+// EOF
+//
+// {
+//     "result": {
+//         "user_id_1": [
+//             "developer",
+//         ],
+//         "user_id_2": [
+//         ],
+//     }
+// }
+type GetRoleHandler struct {
+	AuthInfoStore authinfo.Store `dependency:"AuthInfoStore"`
+	TxContext     db.TxContext   `dependency:"TxContext"`
+}
+
+func (h GetRoleHandler) WithTx() bool {
+	return true
+}
+
+func (h GetRoleHandler) DecodeRequest(request *http.Request) (handler.RequestPayload, error) {
+	payload := GetRoleRequestPayload{}
+	err := json.NewDecoder(request.Body).Decode(&payload)
+	return payload, err
+}
+
+// TODO: Handle getting roles of users specified by user IDs. Users can only
+// get his own roles except that administrators can query roles of other users.
+func (h GetRoleHandler) Handle(req interface{}) (resp interface{}, err error) {
+	payload := req.(GetRoleRequestPayload)
+	roleMap, err := h.AuthInfoStore.GetRoles(payload.UserIDs)
+	if err != nil {
+		err = skyerr.NewError(skyerr.UnexpectedError, "GetRoles failed")
+		return
+	}
+	resp = roleMap
+	return
+}

--- a/pkg/core/auth/authinfo/store.go
+++ b/pkg/core/auth/authinfo/store.go
@@ -28,6 +28,9 @@ type Store interface {
 	// AssignRoles accepts array of roles and userID, the supplied roles will
 	// be assigned to all passed in users
 	AssignRoles(userIDs []string, roles []string) error
+
+	// GetRoles accepts array of userID, and return corresponding roles
+	GetRoles(userIDs []string) (map[string][]string, error)
 }
 
 type StoreProvider struct {


### PR DESCRIPTION
connects #670

## Note

Note that, due to some implementation detail is not confirmed yet, this endpoint will only support admin only temporarily. Developers should fix this API to support user to get its own roles later.

# Not confirmed implementation:
For some special cases, API may have different behavior when incoming request arguments are different. Take `/role/get` as an example, the API has different permission policy according to request access key type (master key or non master key). We should come up with an elegant design to support such behavior.