### PR TITLE
next: add skygear url to tenant configuration

### DIFF
--- a/pkg/core/config/tenant.go
+++ b/pkg/core/config/tenant.go
@@ -26,7 +26,8 @@ type TokenStoreConfiguration struct {
 }
 
 type UserProfileConfiguration struct {
-	ImplName string `msg:"IMPLEMENTATION" envconfig:"USER_PROFILE_IMPL_NAME" json:"IMPLEMENTATION"`
+	ImplName     string `msg:"IMPLEMENTATION" envconfig:"USER_PROFILE_IMPL_NAME" json:"IMPLEMENTATION"`
+	ImplStoreURL string `msg:"IMPL_STORE_URL" envconfig:"USER_PROFILE_IMPL_STORE_URL" json:"IMPL_STORE_URL"`
 }
 
 type UserAuditConfiguration struct {

--- a/pkg/core/config/tenant_gen.go
+++ b/pkg/core/config/tenant_gen.go
@@ -97,6 +97,11 @@ func (z *TenantConfiguration) DecodeMsg(dc *msgp.Reader) (err error) {
 					if err != nil {
 						return
 					}
+				case "IMPL_STORE_URL":
+					z.UserProfile.ImplStoreURL, err = dc.ReadString()
+					if err != nil {
+						return
+					}
 				default:
 					err = dc.Skip()
 					if err != nil {
@@ -213,13 +218,22 @@ func (z *TenantConfiguration) EncodeMsg(en *msgp.Writer) (err error) {
 		return
 	}
 	// write "USER_PROFILE"
-	// map header, size 1
+	// map header, size 2
 	// write "IMPLEMENTATION"
-	err = en.Append(0xac, 0x55, 0x53, 0x45, 0x52, 0x5f, 0x50, 0x52, 0x4f, 0x46, 0x49, 0x4c, 0x45, 0x81, 0xae, 0x49, 0x4d, 0x50, 0x4c, 0x45, 0x4d, 0x45, 0x4e, 0x54, 0x41, 0x54, 0x49, 0x4f, 0x4e)
+	err = en.Append(0xac, 0x55, 0x53, 0x45, 0x52, 0x5f, 0x50, 0x52, 0x4f, 0x46, 0x49, 0x4c, 0x45, 0x82, 0xae, 0x49, 0x4d, 0x50, 0x4c, 0x45, 0x4d, 0x45, 0x4e, 0x54, 0x41, 0x54, 0x49, 0x4f, 0x4e)
 	if err != nil {
 		return err
 	}
 	err = en.WriteString(z.UserProfile.ImplName)
+	if err != nil {
+		return
+	}
+	// write "IMPL_STORE_URL"
+	err = en.Append(0xae, 0x49, 0x4d, 0x50, 0x4c, 0x5f, 0x53, 0x54, 0x4f, 0x52, 0x45, 0x5f, 0x55, 0x52, 0x4c)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.UserProfile.ImplStoreURL)
 	if err != nil {
 		return
 	}
@@ -274,10 +288,13 @@ func (z *TenantConfiguration) MarshalMsg(b []byte) (o []byte, err error) {
 	o = append(o, 0xa6, 0x45, 0x58, 0x50, 0x49, 0x52, 0x59)
 	o = msgp.AppendInt64(o, z.TokenStore.Expiry)
 	// string "USER_PROFILE"
-	// map header, size 1
+	// map header, size 2
 	// string "IMPLEMENTATION"
-	o = append(o, 0xac, 0x55, 0x53, 0x45, 0x52, 0x5f, 0x50, 0x52, 0x4f, 0x46, 0x49, 0x4c, 0x45, 0x81, 0xae, 0x49, 0x4d, 0x50, 0x4c, 0x45, 0x4d, 0x45, 0x4e, 0x54, 0x41, 0x54, 0x49, 0x4f, 0x4e)
+	o = append(o, 0xac, 0x55, 0x53, 0x45, 0x52, 0x5f, 0x50, 0x52, 0x4f, 0x46, 0x49, 0x4c, 0x45, 0x82, 0xae, 0x49, 0x4d, 0x50, 0x4c, 0x45, 0x4d, 0x45, 0x4e, 0x54, 0x41, 0x54, 0x49, 0x4f, 0x4e)
 	o = msgp.AppendString(o, z.UserProfile.ImplName)
+	// string "IMPL_STORE_URL"
+	o = append(o, 0xae, 0x49, 0x4d, 0x50, 0x4c, 0x5f, 0x53, 0x54, 0x4f, 0x52, 0x45, 0x5f, 0x55, 0x52, 0x4c)
+	o = msgp.AppendString(o, z.UserProfile.ImplStoreURL)
 	// string "USER_AUDIT"
 	// map header, size 2
 	// string "ENABLED"
@@ -378,6 +395,11 @@ func (z *TenantConfiguration) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					if err != nil {
 						return
 					}
+				case "IMPL_STORE_URL":
+					z.UserProfile.ImplStoreURL, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						return
+					}
 				default:
 					bts, err = msgp.Skip(bts)
 					if err != nil {
@@ -428,7 +450,7 @@ func (z *TenantConfiguration) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *TenantConfiguration) Msgsize() (s int) {
-	s = 1 + 13 + msgp.StringPrefixSize + len(z.DBConnectionStr) + 8 + msgp.StringPrefixSize + len(z.APIKey) + 11 + msgp.StringPrefixSize + len(z.MasterKey) + 9 + msgp.StringPrefixSize + len(z.AppName) + 10 + msgp.StringPrefixSize + len(z.CORSHost) + 12 + 1 + 7 + msgp.StringPrefixSize + len(z.TokenStore.Secret) + 7 + msgp.Int64Size + 13 + 1 + 15 + msgp.StringPrefixSize + len(z.UserProfile.ImplName) + 11 + 1 + 8 + msgp.BoolSize + 18 + msgp.StringPrefixSize + len(z.UserAudit.TrailHandlerURL)
+	s = 1 + 13 + msgp.StringPrefixSize + len(z.DBConnectionStr) + 8 + msgp.StringPrefixSize + len(z.APIKey) + 11 + msgp.StringPrefixSize + len(z.MasterKey) + 9 + msgp.StringPrefixSize + len(z.AppName) + 10 + msgp.StringPrefixSize + len(z.CORSHost) + 12 + 1 + 7 + msgp.StringPrefixSize + len(z.TokenStore.Secret) + 7 + msgp.Int64Size + 13 + 1 + 15 + msgp.StringPrefixSize + len(z.UserProfile.ImplName) + 15 + msgp.StringPrefixSize + len(z.UserProfile.ImplStoreURL) + 11 + 1 + 8 + msgp.BoolSize + 18 + msgp.StringPrefixSize + len(z.UserAudit.TrailHandlerURL)
 	return
 }
 
@@ -685,6 +707,11 @@ func (z *UserProfileConfiguration) DecodeMsg(dc *msgp.Reader) (err error) {
 			if err != nil {
 				return
 			}
+		case "IMPL_STORE_URL":
+			z.ImplStoreURL, err = dc.ReadString()
+			if err != nil {
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -697,13 +724,22 @@ func (z *UserProfileConfiguration) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z UserProfileConfiguration) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 1
+	// map header, size 2
 	// write "IMPLEMENTATION"
-	err = en.Append(0x81, 0xae, 0x49, 0x4d, 0x50, 0x4c, 0x45, 0x4d, 0x45, 0x4e, 0x54, 0x41, 0x54, 0x49, 0x4f, 0x4e)
+	err = en.Append(0x82, 0xae, 0x49, 0x4d, 0x50, 0x4c, 0x45, 0x4d, 0x45, 0x4e, 0x54, 0x41, 0x54, 0x49, 0x4f, 0x4e)
 	if err != nil {
 		return err
 	}
 	err = en.WriteString(z.ImplName)
+	if err != nil {
+		return
+	}
+	// write "IMPL_STORE_URL"
+	err = en.Append(0xae, 0x49, 0x4d, 0x50, 0x4c, 0x5f, 0x53, 0x54, 0x4f, 0x52, 0x45, 0x5f, 0x55, 0x52, 0x4c)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.ImplStoreURL)
 	if err != nil {
 		return
 	}
@@ -713,10 +749,13 @@ func (z UserProfileConfiguration) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z UserProfileConfiguration) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 1
+	// map header, size 2
 	// string "IMPLEMENTATION"
-	o = append(o, 0x81, 0xae, 0x49, 0x4d, 0x50, 0x4c, 0x45, 0x4d, 0x45, 0x4e, 0x54, 0x41, 0x54, 0x49, 0x4f, 0x4e)
+	o = append(o, 0x82, 0xae, 0x49, 0x4d, 0x50, 0x4c, 0x45, 0x4d, 0x45, 0x4e, 0x54, 0x41, 0x54, 0x49, 0x4f, 0x4e)
 	o = msgp.AppendString(o, z.ImplName)
+	// string "IMPL_STORE_URL"
+	o = append(o, 0xae, 0x49, 0x4d, 0x50, 0x4c, 0x5f, 0x53, 0x54, 0x4f, 0x52, 0x45, 0x5f, 0x55, 0x52, 0x4c)
+	o = msgp.AppendString(o, z.ImplStoreURL)
 	return
 }
 
@@ -741,6 +780,11 @@ func (z *UserProfileConfiguration) UnmarshalMsg(bts []byte) (o []byte, err error
 			if err != nil {
 				return
 			}
+		case "IMPL_STORE_URL":
+			z.ImplStoreURL, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -754,6 +798,6 @@ func (z *UserProfileConfiguration) UnmarshalMsg(bts []byte) (o []byte, err error
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z UserProfileConfiguration) Msgsize() (s int) {
-	s = 1 + 15 + msgp.StringPrefixSize + len(z.ImplName)
+	s = 1 + 15 + msgp.StringPrefixSize + len(z.ImplName) + 15 + msgp.StringPrefixSize + len(z.ImplStoreURL)
 	return
 }

--- a/pkg/gateway/config/config.go
+++ b/pkg/gateway/config/config.go
@@ -33,7 +33,8 @@ func (c *Configuration) ReadFromEnv() error {
 
 // RouterConfig contain gears url
 type RouterConfig struct {
-	AuthGearURL string `envconfig:"AUTH_GEAR_URL" required:"true"`
+	AuthGearURL   string `envconfig:"AUTH_GEAR_URL" required:"true"`
+	RecordGearURL string `envconfig:"RECORD_GEAR_URL"`
 
 	routerMap map[string]*url.URL `ignored:"true"`
 }
@@ -42,8 +43,10 @@ type RouterConfig struct {
 func (r *RouterConfig) GetRouterMap() map[string]*url.URL {
 	if r.routerMap == nil {
 		auth, _ := url.Parse(r.AuthGearURL)
+		record, _ := url.Parse(r.RecordGearURL)
 		r.routerMap = map[string]*url.URL{
-			"auth": auth,
+			"auth":   auth,
+			"record": record,
 		}
 	}
 	return r.routerMap

--- a/pkg/gateway/model/plan.go
+++ b/pkg/gateway/model/plan.go
@@ -7,11 +7,12 @@ import (
 // Plan is skygear subscription plan which provide information whether the app
 // can access the gears
 type Plan struct {
-	ID          string
-	Name        string
-	AuthEnabled bool       `db:"auth_enabled"`
-	CreatedAt   *time.Time `db:"created_at"`
-	UpdatedAt   *time.Time `db:"updated_at"`
+	ID            string
+	Name          string
+	AuthEnabled   bool       `db:"auth_enabled"`
+	RecordEnabled bool       `db:"record_enabled"`
+	CreatedAt     *time.Time `db:"created_at"`
+	UpdatedAt     *time.Time `db:"updated_at"`
 }
 
 // CanAccessGear determine whether the app plan can access the given gear
@@ -19,6 +20,8 @@ func (p *Plan) CanAccessGear(gear string) bool {
 	switch gear {
 	case "auth":
 		return p.AuthEnabled
+	case "record":
+		return p.RecordEnabled
 	default:
 		return false
 	}

--- a/scripts/gateway/migrations/1541398893_add_record_enabled.down.sql
+++ b/scripts/gateway/migrations/1541398893_add_record_enabled.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+SET search_path TO app_config;
+
+ALTER TABLE plan DROP record_enabled;
+
+SET search_path TO DEFAULT;
+
+END;

--- a/scripts/gateway/migrations/1541398893_add_record_enabled.up.sql
+++ b/scripts/gateway/migrations/1541398893_add_record_enabled.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+SET search_path TO app_config;
+
+ALTER TABLE plan ADD record_enabled boolean NOT NULL DEFAULT FALSE;
+
+SET search_path TO DEFAULT;
+
+END;


### PR DESCRIPTION
connects #755 

1. add `SKYGEAR_URL` to `TenantConfiguration`, this is used in auth gear to generate a request to record gear.
2. add `record_enabled` to `Plan` table, it helps gateway to know if it routes record request of an app to record gear.