### PR TITLE
next: Tenant config default

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/skygeario/skygear-server/pkg/core/logging"
 	coreMiddleware "github.com/skygeario/skygear-server/pkg/core/middleware"
+	"github.com/skygeario/skygear-server/pkg/core/server"
 	gatewayConfig "github.com/skygeario/skygear-server/pkg/gateway/config"
 	pqStore "github.com/skygeario/skygear-server/pkg/gateway/db/pq"
 	"github.com/skygeario/skygear-server/pkg/gateway/middleware"
@@ -53,7 +54,9 @@ func main() {
 	gr := r.PathPrefix("/{gear}").Subrouter()
 
 	// RecoverMiddleware must come first
-	gr.Use(coreMiddleware.RecoverMiddleware{}.Handle)
+	gr.Use(coreMiddleware.RecoverMiddleware{
+		RecoverHandler: server.DefaultRecoverPanicHandler,
+	}.Handle)
 	// TODO:
 	// Currently both config and authz middleware both query store to get
 	// app, see how to reduce query to optimize the performance

--- a/pkg/core/config/tenant.go
+++ b/pkg/core/config/tenant.go
@@ -14,7 +14,7 @@ type TenantConfiguration struct {
 	APIKey          string                    `msg:"API_KEY" envconfig:"API_KEY" json:"API_KEY"`
 	MasterKey       string                    `msg:"MASTER_KEY" envconfig:"MASTER_KEY" json:"MASTER_KEY"`
 	AppName         string                    `msg:"APP_NAME" envconfig:"APP_NAME" json:"APP_NAME"`
-	CORSHost        string                    `msg:"CORS_HOST" envconfig:"CORS_HOST" json:"CORS_HOST" default:"*"`
+	CORSHost        string                    `msg:"CORS_HOST" envconfig:"CORS_HOST" json:"CORS_HOST"`
 	TokenStore      TokenStoreConfiguration   `json:"TOKEN_STORE" msg:"TOKEN_STORE"`
 	UserProfile     UserProfileConfiguration  `json:"USER_PROFILE" msg:"USER_PROFILE"`
 	UserAudit       UserAuditConfiguration    `json:"USER_AUDIT" msg:"USER_AUDIT"`
@@ -42,17 +42,17 @@ type UserAuditConfiguration struct {
 
 type SMTPConfiguration struct {
 	Host     string `msg:"HOST" envconfig:"SMTP_HOST" json:"HOST"`
-	Port     int    `msg:"PORT" envconfig:"SMTP_PORT" json:"PORT" default:"25"`
-	Mode     string `msg:"MODE" envconfig:"SMTP_MODE" json:"MODE" default:"normal"`
+	Port     int    `msg:"PORT" envconfig:"SMTP_PORT" json:"PORT"`
+	Mode     string `msg:"MODE" envconfig:"SMTP_MODE" json:"MODE"`
 	Login    string `msg:"LOGIN" envconfig:"SMTP_LOGIN" json:"LOGIN"`
 	Password string `msg:"PASSWORD" envconfig:"SMTP_PASSWORD" json:"PASSWORD"`
 }
 
 type WelcomeEmailConfiguration struct {
-	Enabled     bool   `msg:"ENABLED" envconfig:"WELCOME_EMAIL_ENABLED" json:"ENABLED" default:"false"`
+	Enabled     bool   `msg:"ENABLED" envconfig:"WELCOME_EMAIL_ENABLED" json:"ENABLED"`
 	SenderName  string `msg:"SENDER_NAME" envconfig:"WELCOME_EMAIL_SENDER_NAME" json:"SENDER_NAME"`
-	Sender      string `msg:"SENDER" envconfig:"WELCOME_EMAIL_SENDER" json:"SENDER" default:"no-reply@skygeario.com"`
-	Subject     string `msg:"SUBJECT" envconfig:"WELCOME_EMAIL_SUBJECT" json:"SUBJECT" default:"Welcome!"`
+	Sender      string `msg:"SENDER" envconfig:"WELCOME_EMAIL_SENDER" json:"SENDER"`
+	Subject     string `msg:"SUBJECT" envconfig:"WELCOME_EMAIL_SUBJECT" json:"SUBJECT"`
 	ReplyToName string `msg:"REPLY_TO_NAME" envconfig:"WELCOME_EMAIL_REPLY_TO_NAME" json:"REPLY_TO_NAME"`
 	ReplyTo     string `msg:"REPLY_TO" envconfig:"WELCOME_EMAIL_REPLY_TO" json:"REPLY_TO"`
 	TextURL     string `msg:"TEXT_URL" envconfig:"WELCOME_EMAIL_TEXT_URL" json:"TEXT_URL"`
@@ -74,8 +74,20 @@ type SSOConfiguration struct {
 	Scope        string `msg:"SCOPE" envconfig:"SCOPE" json:"SCOPE"`
 }
 
-func (c *TenantConfiguration) ReadFromEnv() error {
-	return envconfig.Process("", c)
+func NewTenantConfiguration() TenantConfiguration {
+	return TenantConfiguration{
+		DBConnectionStr: "postgres://postgres:@localhost/postgres?sslmode=disable",
+		CORSHost:        "*",
+		SMTP: SMTPConfiguration{
+			Port: 25,
+			Mode: "normal",
+		},
+		WelcomeEmail: WelcomeEmailConfiguration{
+			Enabled: false,
+			Sender:  "no-reply@skygeario.com",
+			Subject: "Welcome!",
+		},
+	}
 }
 
 func (c *TenantConfiguration) DefaultSensitiveLoggerValues() []string {
@@ -130,7 +142,7 @@ func SetTenantConfig(i interface{}, t TenantConfiguration) {
 
 // NewTenantConfigurationFromEnv implements ConfigurationProvider
 func NewTenantConfigurationFromEnv(_ *http.Request) (TenantConfiguration, error) {
-	c := TenantConfiguration{}
+	c := NewTenantConfiguration()
 	err := envconfig.Process("", &c)
 	c.SSOSetting = getSSOSetting()
 	c.SSOConfigs = getSSOConfigs(c.SSOProviders)

--- a/pkg/core/config/tenant_test.go
+++ b/pkg/core/config/tenant_test.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestTenantConfig(t *testing.T) {
+	Convey("Test TenantConfiguration", t, func() {
+		Convey("should load tenant config correctly from env", func() {
+			os.Clearenv()
+			os.Setenv("API_KEY", "testapikey")
+			os.Setenv("MASTER_KEY", "testmasterkey")
+			os.Setenv("APP_NAME", "testappname")
+			os.Setenv("WELCOME_EMAIL_ENABLED", "true")
+
+			config, err := NewTenantConfigurationFromEnv(nil)
+
+			So(err, ShouldBeNil)
+			So(config.APIKey, ShouldEqual, "testapikey")
+			So(config.MasterKey, ShouldEqual, "testmasterkey")
+			So(config.AppName, ShouldEqual, "testappname")
+			So(config.WelcomeEmail.Enabled, ShouldEqual, true)
+		})
+
+		Convey("should have default value when load from env", func() {
+			os.Clearenv()
+			os.Setenv("API_KEY", "testapikey")
+			os.Setenv("MASTER_KEY", "testmasterkey")
+			os.Setenv("APP_NAME", "testappname")
+
+			config, err := NewTenantConfigurationFromEnv(nil)
+
+			So(err, ShouldBeNil)
+			So(config.CORSHost, ShouldEqual, "*")
+			So(config.SMTP.Port, ShouldEqual, 25)
+		})
+
+		Convey("should use master key as token secret if it is not provided in env", func() {
+			os.Clearenv()
+			os.Setenv("API_KEY", "testapikey")
+			os.Setenv("MASTER_KEY", "testmasterkey")
+			os.Setenv("APP_NAME", "testappname")
+
+			config, err := NewTenantConfigurationFromEnv(nil)
+
+			So(err, ShouldBeNil)
+			So(config.TokenStore.Secret, ShouldEqual, "testmasterkey")
+		})
+
+		Convey("should validate when load from env", func() {
+			os.Clearenv()
+
+			_, err := NewTenantConfigurationFromEnv(nil)
+
+			So(err, ShouldBeError)
+		})
+
+		Convey("should have default value when load from JSON", func() {
+			b := []byte(`{
+				"API_KEY": "testapikey",
+				"APP_NAME": "testappname",
+				"MASTER_KEY": "testmasterkey",
+				"WELCOME_EMAIL": {
+					"ENABLED": true
+				}
+			}`)
+
+			config := NewTenantConfiguration()
+			err := json.Unmarshal(b, &config)
+
+			So(err, ShouldBeNil)
+			So(config.APIKey, ShouldEqual, "testapikey")
+			So(config.MasterKey, ShouldEqual, "testmasterkey")
+			So(config.AppName, ShouldEqual, "testappname")
+			So(config.WelcomeEmail.Enabled, ShouldEqual, true)
+		})
+
+		Convey("should load tenant config correctly from JSON", func() {
+			b := []byte(`{
+				"API_KEY": "testapikey",
+				"APP_NAME": "testappname",
+				"MASTER_KEY": "testmasterkey"
+			}`)
+
+			config := NewTenantConfiguration()
+			err := json.Unmarshal(b, &config)
+
+			So(err, ShouldBeNil)
+			So(config.CORSHost, ShouldEqual, "*")
+			So(config.SMTP.Port, ShouldEqual, 25)
+		})
+
+		Convey("should use master key as token secret if it is not provided in JSON", func() {
+			b := []byte(`{
+				"API_KEY": "testapikey",
+				"APP_NAME": "testappname",
+				"MASTER_KEY": "testmasterkey"
+			}`)
+
+			config := NewTenantConfiguration()
+			err := json.Unmarshal(b, &config)
+
+			So(err, ShouldBeNil)
+			So(config.TokenStore.Secret, ShouldEqual, "testmasterkey")
+		})
+
+		Convey("should validate when load from JSON", func() {
+			b := []byte(`{}`)
+
+			config := NewTenantConfiguration()
+			err := json.Unmarshal(b, &config)
+
+			So(err, ShouldBeError)
+		})
+
+		Convey("should be the same config after set and get from header", func() {
+			config := NewTenantConfiguration()
+			config.APIKey = "testapikey"
+			config.MasterKey = "testmasterkey"
+			config.AppName = "testappname"
+
+			req, _ := http.NewRequest("POST", "", nil)
+
+			SetTenantConfig(req, config)
+			newConfig := GetTenantConfig(req)
+			So(newConfig, ShouldResemble, config)
+		})
+	})
+}

--- a/pkg/core/middleware/tenant.go
+++ b/pkg/core/middleware/tenant.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/skygeario/skygear-server/pkg/core/config"
@@ -25,8 +26,7 @@ func (m TenantConfigurationMiddleware) Handle(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		configuration, err := m.ProvideConfig(r)
 		if err != nil {
-			http.Error(w, "Unable to retrieve configuration", http.StatusInternalServerError)
-			return
+			panic(fmt.Errorf("Unable to retrieve configuration: %v", err.Error()))
 		}
 
 		// Tenant authentication

--- a/pkg/core/middleware/tenant_test.go
+++ b/pkg/core/middleware/tenant_test.go
@@ -77,11 +77,15 @@ func TestMiddleware(t *testing.T) {
 		errHandler := targetErrMiddleware.Handle(GetTestHandler())
 
 		Convey("should handle request with error config provider", func() {
+			defer func() {
+				r := recover()
+				err, _ := r.(error)
+				So(err.Error(), ShouldEqual, "Unable to retrieve configuration: feature not supported")
+			}()
+
 			req := newReq()
 			resp := httptest.NewRecorder()
 			errHandler.ServeHTTP(resp, req)
-			So(resp.Code, ShouldEqual, http.StatusInternalServerError)
-			So(resp.Body.String(), ShouldEqual, "Unable to retrieve configuration\n")
 		})
 	})
 }

--- a/pkg/core/server/option.go
+++ b/pkg/core/server/option.go
@@ -19,19 +19,21 @@ type RecoveredResponse struct {
 	Err skyerr.Error `json:"error,omitempty"`
 }
 
+func DefaultRecoverPanicHandler(w http.ResponseWriter, r *http.Request, err skyerr.Error) {
+	httpStatus := nextSkyerr.ErrorDefaultStatusCode(err)
+
+	// TODO: log
+
+	response := RecoveredResponse{Err: err}
+	encoder := json.NewEncoder(w)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(httpStatus)
+	encoder.Encode(response)
+}
+
 func DefaultOption() Option {
 	return Option{
-		RecoverPanic: true,
-		RecoverPanicHandler: func(w http.ResponseWriter, r *http.Request, err skyerr.Error) {
-			httpStatus := nextSkyerr.ErrorDefaultStatusCode(err)
-
-			// TODO: log
-
-			response := RecoveredResponse{Err: err}
-			encoder := json.NewEncoder(w)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(httpStatus)
-			encoder.Encode(response)
-		},
+		RecoverPanic:        true,
+		RecoverPanicHandler: DefaultRecoverPanicHandler,
 	}
 }

--- a/pkg/gateway/db/pq/app.go
+++ b/pkg/gateway/db/pq/app.go
@@ -44,7 +44,7 @@ func (s *Store) GetAppByDomain(domain string, app *model.App) error {
 		return err
 	}
 
-	configValue := tenantConfigurationValue{}
+	configValue := newTenantConfigurationValue()
 	if err := s.getConfigByID(configID, &configValue); err != nil {
 		logger.WithError(err).Error("Fail to get app tenant config")
 		return err

--- a/pkg/gateway/db/pq/types.go
+++ b/pkg/gateway/db/pq/types.go
@@ -14,6 +14,12 @@ type tenantConfigurationValue struct {
 	Valid               bool
 }
 
+func newTenantConfigurationValue() tenantConfigurationValue {
+	return tenantConfigurationValue{
+		TenantConfiguration: config.NewTenantConfiguration(),
+	}
+}
+
 func (v tenantConfigurationValue) Value() (driver.Value, error) {
 	if !v.Valid {
 		return nil, nil


### PR DESCRIPTION
connect #791

- Default value and validation are for env and json config source only. Since we used msgp for transporting through request header, which is not the config source. The input and output will be the same and the default value and validation is not applied
- Allow static default by updating `NewTenantConfiguration`
- Allow a degree of flexible to update dynamic default in `AfterUnmarshal`
- SkygearIO/py-skygear#232 is not addressed here, since gear communicate is through public gateway now. And we may want to revisit in when we do cloud function and see if it is still valid.