### PR TITLE
next: SSO should support auto link existed user account

### DIFF
--- a/pkg/auth/dependency/sso/mock_provider.go
+++ b/pkg/auth/dependency/sso/mock_provider.go
@@ -5,11 +5,11 @@ import (
 )
 
 type MockSSOProverImpl struct {
-	BaseURL      string
-	Setting      Setting
-	Config       Config
-	MockUserID   string
-	MockAuthData map[string]interface{}
+	BaseURL  string
+	Setting  Setting
+	Config   Config
+	UserID   string
+	AuthData map[string]interface{}
 }
 
 func (f *MockSSOProverImpl) GetAuthURL(params GetURLParams) (string, error) {
@@ -39,10 +39,10 @@ func (f *MockSSOProverImpl) GetAuthInfo(code string, scope Scope, encodedState s
 	authInfo = AuthInfo{
 		ProviderName:            f.Config.Name,
 		State:                   state,
-		ProviderUserID:          f.MockUserID,
+		ProviderUserID:          f.UserID,
 		ProviderAccessTokenResp: map[string]interface{}{},
 		ProviderUserProfile:     map[string]interface{}{},
-		ProviderAuthData:        f.MockAuthData,
+		ProviderAuthData:        f.AuthData,
 	}
 	return
 }

--- a/pkg/auth/dependency/userprofile/mock_store.go
+++ b/pkg/auth/dependency/userprofile/mock_store.go
@@ -1,8 +1,9 @@
 package userprofile
 
 import (
-	"github.com/skygeario/skygear-server/pkg/core/auth/authinfo"
 	"time"
+
+	"github.com/skygeario/skygear-server/pkg/core/auth/authinfo"
 )
 
 type MockUserProfileStoreImpl struct {
@@ -15,6 +16,13 @@ type MockTimeNowfunc func() time.Time
 func NewMockUserProfileStore() *MockUserProfileStoreImpl {
 	return &MockUserProfileStoreImpl{
 		Data:        map[string]map[string]interface{}{},
+		TimeNowfunc: func() time.Time { return time.Time{} },
+	}
+}
+
+func NewMockUserProfileStoreByData(data map[string]map[string]interface{}) *MockUserProfileStoreImpl {
+	return &MockUserProfileStoreImpl{
+		Data:        data,
 		TimeNowfunc: func() time.Time { return time.Time{} },
 	}
 }

--- a/pkg/auth/handler/sso/auth_handler_test.go
+++ b/pkg/auth/handler/sso/auth_handler_test.go
@@ -85,10 +85,10 @@ func TestAuthHandler(t *testing.T) {
 			ClientSecret: "mock_client_secret",
 		}
 		mockProvider := sso.MockSSOProverImpl{
-			BaseURL:    "http://mock/auth",
-			Setting:    setting,
-			Config:     config,
-			MockUserID: providerUserID,
+			BaseURL: "http://mock/auth",
+			Setting: setting,
+			Config:  config,
+			UserID:  providerUserID,
 		}
 		sh.Provider = &mockProvider
 		mockOAuthProvider := oauth.NewMockProvider(
@@ -455,6 +455,190 @@ func TestAuthHandler(t *testing.T) {
 			sh.ServeHTTP(resp, req)
 			So(resp.Code, ShouldEqual, 400)
 			So(resp.Body.String(), ShouldEqual, "InvalidArgument: provider account already linked with existing user\n")
+		})
+	})
+
+	Convey("Test AuthHandler's auto link procedure", t, func() {
+		action := "login"
+		UXMode := "web_redirect"
+
+		stateJWTSecret := "secret"
+		providerName := "mock"
+		providerUserID := "mock_user_id"
+		sh := &AuthHandler{}
+		sh.TxContext = db.NewMockTxContext()
+		sh.AuthContext = auth.NewMockContextGetterWithDefaultUser()
+		setting := sso.Setting{
+			URLPrefix:      "http://localhost:3000",
+			StateJWTSecret: stateJWTSecret,
+			AllowedCallbackURLs: []string{
+				"http://localhost",
+			},
+		}
+		config := sso.Config{
+			Name:         providerName,
+			ClientID:     "mock_client_id",
+			ClientSecret: "mock_client_secret",
+		}
+		mockProvider := sso.MockSSOProverImpl{
+			BaseURL: "http://mock/auth",
+			Setting: setting,
+			Config:  config,
+			UserID:  providerUserID,
+			AuthData: map[string]interface{}{
+				"email": "john.doe@example.com",
+			},
+		}
+		sh.Provider = &mockProvider
+		mockOAuthProvider := oauth.NewMockProvider(
+			map[string]string{},
+			map[string]oauth.Principal{},
+		)
+		sh.OAuthAuthProvider = mockOAuthProvider
+		authInfoStore := authinfo.NewMockStoreWithAuthInfoMap(
+			map[string]authinfo.AuthInfo{
+				"john.doe.id": authinfo.AuthInfo{
+					ID: "john.doe.id",
+				},
+			},
+		)
+		sh.AuthInfoStore = authInfoStore
+		mockTokenStore := authtoken.NewMockStore()
+		sh.TokenStore = mockTokenStore
+		profileData := map[string]map[string]interface{}{
+			"john.doe.id": map[string]interface{}{},
+		}
+		sh.UserProfileStore = userprofile.NewMockUserProfileStoreByData(profileData)
+		sh.RoleStore = role.NewMockStore()
+		sh.AuthHandlerHTMLProvider = sso.NewAuthHandlerHTMLProvider(
+			"https://api.example.com",
+			"https://api.example.com/skygear.js",
+		)
+		sh.SSOSetting = setting
+		authRecordKeys := [][]string{[]string{"email"}}
+		passwordAuthProvider := password.NewMockProviderWithPrincipalMap(
+			authRecordKeys,
+			map[string]password.Principal{
+				"john.doe.principal.id": password.Principal{
+					ID:     "john.doe.principal.id",
+					UserID: "john.doe.id",
+					AuthData: map[string]interface{}{
+						"email": "john.doe@example.com",
+					},
+					HashedPassword: []byte("$2a$10$/jm/S1sY6ldfL6UZljlJdOAdJojsJfkjg/pqK47Q8WmOLE19tGWQi"), // 123456
+				},
+			},
+		)
+		sh.PasswordAuthProvider = passwordAuthProvider
+
+		Convey("should auto-link password principal", func() {
+			// oauth state
+			state := sso.State{
+				CallbackURL: "http://localhost:3000",
+				UXMode:      UXMode,
+				Action:      action,
+			}
+			encodedState, _ := sso.EncodeState(stateJWTSecret, state)
+
+			v := url.Values{}
+			v.Set("code", "code")
+			v.Add("state", encodedState)
+			u := url.URL{
+				RawQuery: v.Encode(),
+			}
+
+			req, _ := http.NewRequest("GET", u.RequestURI(), nil)
+			resp := httptest.NewRecorder()
+
+			sh.ServeHTTP(resp, req)
+
+			oauthPrincipal, err := sh.OAuthAuthProvider.GetPrincipalByProviderUserID(providerName, providerUserID)
+			So(err, ShouldBeNil)
+			So(oauthPrincipal.UserID, ShouldEqual, "john.doe.id")
+		})
+	})
+
+	Convey("Test AuthHandler's auto link procedure", t, func() {
+		action := "login"
+		UXMode := "web_redirect"
+
+		stateJWTSecret := "secret"
+		providerName := "mock"
+		providerUserID := "mock_user_id"
+		sh := &AuthHandler{}
+		sh.TxContext = db.NewMockTxContext()
+		sh.AuthContext = auth.NewMockContextGetterWithDefaultUser()
+		setting := sso.Setting{
+			URLPrefix:      "http://localhost:3000",
+			StateJWTSecret: stateJWTSecret,
+			AllowedCallbackURLs: []string{
+				"http://localhost",
+			},
+		}
+		config := sso.Config{
+			Name:         providerName,
+			ClientID:     "mock_client_id",
+			ClientSecret: "mock_client_secret",
+		}
+		mockProvider := sso.MockSSOProverImpl{
+			BaseURL: "http://mock/auth",
+			Setting: setting,
+			Config:  config,
+			UserID:  providerUserID,
+			AuthData: map[string]interface{}{
+				"email": "john.doe@example.com",
+			},
+		}
+		sh.Provider = &mockProvider
+		mockOAuthProvider := oauth.NewMockProvider(
+			map[string]string{},
+			map[string]oauth.Principal{},
+		)
+		sh.OAuthAuthProvider = mockOAuthProvider
+		authInfoStore := authinfo.NewMockStoreWithAuthInfoMap(
+			map[string]authinfo.AuthInfo{},
+		)
+		sh.AuthInfoStore = authInfoStore
+		mockTokenStore := authtoken.NewMockStore()
+		sh.TokenStore = mockTokenStore
+		sh.UserProfileStore = userprofile.NewMockUserProfileStore()
+		sh.RoleStore = role.NewMockStore()
+		sh.AuthHandlerHTMLProvider = sso.NewAuthHandlerHTMLProvider(
+			"https://api.example.com",
+			"https://api.example.com/skygear.js",
+		)
+		sh.SSOSetting = setting
+		authRecordKeys := [][]string{[]string{"email"}}
+		passwordAuthProvider := password.NewMockProviderWithPrincipalMap(
+			authRecordKeys,
+			map[string]password.Principal{},
+		)
+		sh.PasswordAuthProvider = passwordAuthProvider
+
+		Convey("should also create an empty password principal", func() {
+			// oauth state
+			state := sso.State{
+				CallbackURL: "http://localhost:3000",
+				UXMode:      UXMode,
+				Action:      action,
+			}
+			encodedState, _ := sso.EncodeState(stateJWTSecret, state)
+
+			v := url.Values{}
+			v.Set("code", "code")
+			v.Add("state", encodedState)
+			u := url.URL{
+				RawQuery: v.Encode(),
+			}
+
+			req, _ := http.NewRequest("GET", u.RequestURI(), nil)
+			resp := httptest.NewRecorder()
+
+			sh.ServeHTTP(resp, req)
+
+			oauthPrincipal, _ := sh.OAuthAuthProvider.GetPrincipalByProviderUserID(providerName, providerUserID)
+			_, err := sh.PasswordAuthProvider.GetPrincipalsByUserID(oauthPrincipal.UserID)
+			So(err, ShouldBeNil)
 		})
 	})
 }

--- a/pkg/auth/handler/sso/sso.go
+++ b/pkg/auth/handler/sso/sso.go
@@ -126,9 +126,13 @@ func (h respHandler) handleLogin(
 		err = nil
 	}
 
-	if valid := h.PasswordAuthProvider.IsAuthDataMatching(oauthAuthInfo.ProviderAuthData); valid {
-		// provider authData match app authRecordKeys,
-		// start auto-connect procedure
+	if valid := h.PasswordAuthProvider.IsAuthDataValid(oauthAuthInfo.ProviderAuthData); valid {
+		// provider authData matches app's authRecordKeys,
+		// then it starts auto-link procedure.
+		//
+		// for example, if oauthAuthInfo.ProviderAuthData is {"email", "john.doe@example.com"},
+		// it will be a valid authData if authRecordKeys is [["username"], ["email"]] or [["email"]]
+		// so, the oauthAuthInfo.ProviderAuthDat can be used as a password principal authData
 		principal, err = h.authLinkUser(oauthAuthInfo)
 		if err != nil {
 			return
@@ -223,9 +227,9 @@ func (h respHandler) createPrincipalByOAuthInfo(userID string, oauthAuthInfo sso
 }
 
 func (h respHandler) createEmptyPasswordPrincipal(userID string, oauthAuthInfo sso.AuthInfo) error {
-	if valid := h.PasswordAuthProvider.IsAuthDataMatching(oauthAuthInfo.ProviderAuthData); valid {
-		// if ProviderAuthData mastch authRecordKeys, also creates an empty password principal
-		// and later the user can set password to it
+	if valid := h.PasswordAuthProvider.IsAuthDataValid(oauthAuthInfo.ProviderAuthData); valid {
+		// if ProviderAuthData mastches authRecordKeys, and it can't be link with current account,
+		// we also creates an empty password principal for later the user can set password to it
 		return h.PasswordAuthProvider.CreatePrincipalsByAuthData(userID, "", oauthAuthInfo.ProviderAuthData)
 	}
 

--- a/pkg/auth/handler/sso/sso.go
+++ b/pkg/auth/handler/sso/sso.go
@@ -126,7 +126,14 @@ func (h respHandler) handleLogin(
 		err = nil
 	}
 
-	// TODO: handle auto link user
+	if valid := h.PasswordAuthProvider.IsAuthDataMatching(oauthAuthInfo.ProviderAuthData); valid {
+		// provider authData match app authRecordKeys,
+		// start auto-connect procedure
+		principal, err = h.authLinkUser(oauthAuthInfo)
+		if err != nil {
+			return
+		}
+	}
 
 	if principal == nil {
 		createNewUser = true
@@ -158,6 +165,11 @@ func (h respHandler) handleLogin(
 		}
 
 		_, err = h.createPrincipalByOAuthInfo(info.ID, oauthAuthInfo)
+		if err != nil {
+			return
+		}
+
+		err = h.createEmptyPasswordPrincipal(info.ID, oauthAuthInfo)
 	} else {
 		principal.AccessTokenResp = oauthAuthInfo.ProviderAccessTokenResp
 		principal.UserProfile = oauthAuthInfo.ProviderUserProfile
@@ -180,6 +192,22 @@ func (h respHandler) handleLogin(
 	return
 }
 
+func (h respHandler) authLinkUser(oauthAuthInfo sso.AuthInfo) (*oauth.Principal, error) {
+	principal := password.Principal{}
+	e := h.PasswordAuthProvider.GetPrincipalByAuthData(oauthAuthInfo.ProviderAuthData, &principal)
+	if e == nil {
+		userID := principal.UserID
+		// link user
+		principal, err := h.createPrincipalByOAuthInfo(userID, oauthAuthInfo)
+		if err != nil {
+			return nil, err
+		}
+		return &principal, nil
+	}
+
+	return nil, nil
+}
+
 func (h respHandler) createPrincipalByOAuthInfo(userID string, oauthAuthInfo sso.AuthInfo) (oauth.Principal, error) {
 	now := timeNow()
 	principal := oauth.NewPrincipal()
@@ -192,4 +220,14 @@ func (h respHandler) createPrincipalByOAuthInfo(userID string, oauthAuthInfo sso
 	principal.UpdatedAt = &now
 	err := h.OAuthAuthProvider.CreatePrincipal(principal)
 	return principal, err
+}
+
+func (h respHandler) createEmptyPasswordPrincipal(userID string, oauthAuthInfo sso.AuthInfo) error {
+	if valid := h.PasswordAuthProvider.IsAuthDataMatching(oauthAuthInfo.ProviderAuthData); valid {
+		// if ProviderAuthData mastch authRecordKeys, also creates an empty password principal
+		// and later the user can set password to it
+		return h.PasswordAuthProvider.CreatePrincipalsByAuthData(userID, "", oauthAuthInfo.ProviderAuthData)
+	}
+
+	return nil
 }


### PR DESCRIPTION
connects #841 

1. If app's authRecordKeys contains ['email'], then auto connect procedure will be executed.
2. If auto connect is executed, it will find corresponding password principal base on authData (which is a map contains provider email), if it finds one, then will use it as the user principal.
3. When signup a new user, and app's authRecordKeys contains ['email], it will generate an empty password principal as well.