### PR TITLE
next: update sso config api to always return authorized_urls, return empty array when it is empty.

### DIFF
--- a/pkg/auth/handler/sso/config.go
+++ b/pkg/auth/handler/sso/config.go
@@ -25,7 +25,7 @@ type ConfigHandler struct {
 }
 
 type ConfigResp struct {
-	AuthorizedURLS []string `json:"authorized_urls,omitempty"`
+	AuthorizedURLS []string `json:"authorized_urls"`
 }
 
 // NewHandler returns the SSO configs.
@@ -52,8 +52,12 @@ type ConfigResp struct {
 func (f ConfigHandler) NewHandler(request *http.Request) http.Handler {
 	handleAPICall := func(r *http.Request) (apiResp handler.APIResponse) {
 		tConfig := config.GetTenantConfig(r)
+		authorizedURLs := tConfig.SSOSetting.AllowedCallbackURLs
+		if authorizedURLs == nil {
+			authorizedURLs = []string{}
+		}
 		resp := ConfigResp{
-			AuthorizedURLS: tConfig.SSOSetting.AllowedCallbackURLs,
+			AuthorizedURLS: authorizedURLs,
 		}
 		apiResp.Result = resp
 


### PR DESCRIPTION
When authorized_urls is empty, that means allow all urls. SDK assumes authorized_urls key
always exists. API should return empty array when it is empty.