### PR TITLE
add tcp keepalive option for APNS connection

### DIFF
--- a/main.go
+++ b/main.go
@@ -589,6 +589,7 @@ func initCertBasedAPNSPusher(
 		push.GatewayType(config.APNS.Env),
 		cert,
 		key,
+		config.APNS.Keepalive,
 	)
 	if err != nil {
 		logger.Fatalf("Failed to set up push sender: %v", err)
@@ -619,6 +620,7 @@ func initTokenBasedAPNSPusher(
 		config.APNS.TokenConfig.TeamID,
 		config.APNS.TokenConfig.KeyID,
 		key,
+		config.APNS.Keepalive,
 	)
 	if err != nil {
 		logger.Fatalf("Failed to set up push sender: %v", err)

--- a/pkg/server/push/cert_apns_test.go
+++ b/pkg/server/push/cert_apns_test.go
@@ -73,7 +73,7 @@ g723fJntDb71I1IS31Vd2wqqpVB4kDp8OiPnPp8ats/cNUFk77Jhxw==
 -----END RSA PRIVATE KEY-----`
 
 	Convey("create cert based APNS from cert and key", t, func() {
-		pusher, err := NewCertBasedAPNSPusher(nil, Sandbox, APNSCert, APNSKey)
+		pusher, err := NewCertBasedAPNSPusher(nil, Sandbox, APNSCert, APNSKey, 0)
 		So(err, ShouldBeNil)
 		So(pusher, ShouldNotBeNil)
 		So(pusher.(*certBasedAPNSPusher).topic, ShouldEqual, "com.example.App")

--- a/pkg/server/push/token_apns_test.go
+++ b/pkg/server/push/token_apns_test.go
@@ -39,6 +39,7 @@ func TestTokenBaseAPNSPusherCreate(t *testing.T) {
 			"test-team-id",
 			"test-key-id",
 			testTokenKey,
+			0,  // tcp keepalive
 		)
 		So(err, ShouldBeNil)
 		So(pusher, ShouldNotBeNil)
@@ -56,6 +57,7 @@ func TestTokenBaseAPNSPusherSend(t *testing.T) {
 			"test-team-id",
 			"test-key-id",
 			testTokenKey,
+			0,  // tcp keepalive
 		)
 		So(err, ShouldBeNil)
 
@@ -207,6 +209,7 @@ func TestTokenBaseAPNSPusherFeedbackInterface(t *testing.T) {
 			"test-team-id",
 			"test-key-id",
 			testTokenKey,
+			0,  // tcp keepalive
 		)
 		So(err, ShouldBeNil)
 

--- a/pkg/server/skyconfig/config.go
+++ b/pkg/server/skyconfig/config.go
@@ -175,9 +175,10 @@ type Configuration struct {
 		} `json:"cloud"`
 	} `json:"asset_store"`
 	APNS struct {
-		Enable bool   `json:"enable"`
-		Type   string `json:"type"`
-		Env    string `json:"env"`
+		Enable    bool   `json:"enable"`
+		Type      string `json:"type"`
+		Env       string `json:"env"`
+		Keepalive int    `json:"keepalive"`
 
 		CertConfig struct {
 			Cert     string `json:"cert"`
@@ -258,6 +259,7 @@ func NewConfiguration() Configuration {
 	config.APNS.Enable = false
 	config.APNS.Type = "cert"
 	config.APNS.Env = "sandbox"
+	config.APNS.Keepalive = 180
 	config.GCM.Enable = false
 	config.Baidu.Enable = false
 	config.LOG.Level = "debug"
@@ -520,6 +522,11 @@ func (config *Configuration) readAPNS() {
 	apnsType := os.Getenv("APNS_TYPE")
 	if apnsType != "" {
 		config.APNS.Type = apnsType
+	}
+
+	// Default to 180s, set to zero to disable tcp keepalive
+	if v, err := strconv.ParseInt(os.Getenv("APNS_KEEPALIVE"), 10, 0); err == nil && v >= 0 {
+		config.APNS.Keepalive = int(v)
 	}
 
 	switch strings.ToLower(config.APNS.Type) {


### PR DESCRIPTION
APNS use HTTP/2 and multiplex multiple payload on same TCP
connection, which default disabled TCP keepalive mechanic,
or otherwise rely on system-level setting of like 7200 seconds.

Such connection, when idle, could be dropped by NAT or firewall,
and we will only receive TCP read error after a long timeout
of 3~30 minutes, furthermore any PN queued in such connection
will fail and discarded.

To deal with this, we shall allow setting a tcp keepalive option.