### PR TITLE
Fix nexmo sms sender error handling

### DIFF
--- a/pkg/core/sms/nexmo.go
+++ b/pkg/core/sms/nexmo.go
@@ -39,7 +39,13 @@ func (n *NexmoClient) Send(to string, body string) error {
 	}
 
 	if resp.MessageCount == 0 {
-		err = errors.New("Unable to send sms")
+		err = errors.New("No sms is sent")
+		return err
+	}
+
+	report := resp.Messages[0]
+	if report.ErrorText != "" {
+		err = errors.New(report.ErrorText)
 		return err
 	}
 


### PR DESCRIPTION
connect #870 

Check the message report return from nexmo client, and return the error when fail to send sms