### PR TITLE
Fix gear /healthz endpoint

### DIFF
--- a/pkg/core/server/server.go
+++ b/pkg/core/server/server.go
@@ -45,9 +45,11 @@ func NewServerWithOption(
 	option Option,
 ) Server {
 	router := mux.NewRouter()
+	router.HandleFunc("/healthz", HealthCheckHandler)
 
+	subRouter := router.NewRoute().Subrouter()
 	srv := Server{
-		router: router,
+		router: subRouter,
 		Server: &http.Server{
 			Addr:         addr,
 			WriteTimeout: time.Second * 15,
@@ -63,8 +65,6 @@ func NewServerWithOption(
 			RecoverHandler: option.RecoverPanicHandler,
 		}.Handle)
 	}
-
-	srv.router.HandleFunc("/healthz", HealthCheckHandler)
 
 	return srv
 }


### PR DESCRIPTION
connect #810

Skip all middleware for healthz endpoint

We added tenant config decode middleware in all gear routes, which healthz endpoint should
not go through the same flow.