### PR TITLE
Fix server crash when receiving pq listener event=2

### DIFF
--- a/pkg/server/skydb/pq/listener.go
+++ b/pkg/server/skydb/pq/listener.go
@@ -119,6 +119,13 @@ func (l *recordListener) Listen() {
 		case pqNotification := <-listener.Notify:
 			l.logger.WithField("pqNotification", pqNotification).Infoln("Received a notify")
 
+			if pqNotification == nil {
+				// After reconnected db, a
+				// nil pq.Notification is sent on the Listener.Notify channel.
+				l.logger.Warnln("pq/listener: got nil notification")
+				continue
+			}
+
 			n := notification{}
 			if err := l.fetchNotification(pqNotification.Extra, &n); err != nil {
 				l.logger.WithFields(logrus.Fields{


### PR DESCRIPTION
connect #136

When the pq listener reconnected to server, and nil notification will be sent to the Listener.Notify channel.
Updated to handle the nil notification.

refs: https://godoc.org/github.com/lib/pq#NewListener
> // ListenerEventReconnected is emitted after a database connection has
> // been re-established after connection loss. The err argument of the
> // callback will always be nil. After this event has been emitted, a
> // nil pq.Notification is sent on the Listener.Notify channel.

To test it, stop the db and start it again