### PR TITLE
Update cloud code model

### DIFF
--- a/cmd/migrate/revisions/gateway/1554279410_remove_cloud_code_config.down.sql
+++ b/cmd/migrate/revisions/gateway/1554279410_remove_cloud_code_config.down.sql
@@ -1,0 +1,6 @@
+-- Put downgrade SQL here
+ALTER TABLE cloud_code ADD COLUMN "config" jsonb;
+
+UPDATE cloud_code SET "config" = '{}'::jsonb;
+
+ALTER TABLE cloud_code ALTER COLUMN "config" SET NOT NULL;

--- a/cmd/migrate/revisions/gateway/1554279410_remove_cloud_code_config.up.sql
+++ b/cmd/migrate/revisions/gateway/1554279410_remove_cloud_code_config.up.sql
@@ -1,0 +1,2 @@
+-- Put upgrade SQL here
+ALTER TABLE cloud_code DROP COLUMN "config";

--- a/cmd/migrate/revisions/gateway/1554280667_rename_to_cloud_code_route.down.sql
+++ b/cmd/migrate/revisions/gateway/1554280667_rename_to_cloud_code_route.down.sql
@@ -1,0 +1,2 @@
+-- Put downgrade SQL here
+ALTER TABLE cloud_code_route RENAME TO cloud_code;

--- a/cmd/migrate/revisions/gateway/1554280667_rename_to_cloud_code_route.up.sql
+++ b/cmd/migrate/revisions/gateway/1554280667_rename_to_cloud_code_route.up.sql
@@ -1,0 +1,2 @@
+-- Put upgrade SQL here
+ALTER TABLE cloud_code RENAME TO cloud_code_route;

--- a/cmd/migrate/revisions/gateway/1554378292_remove_cloud_code_backend_url_default.down.sql
+++ b/cmd/migrate/revisions/gateway/1554378292_remove_cloud_code_backend_url_default.down.sql
@@ -1,0 +1,2 @@
+-- Put downgrade SQL here
+ALTER TABLE cloud_code_route ALTER COLUMN backend_url SET DEFAULT '';

--- a/cmd/migrate/revisions/gateway/1554378292_remove_cloud_code_backend_url_default.up.sql
+++ b/cmd/migrate/revisions/gateway/1554378292_remove_cloud_code_backend_url_default.up.sql
@@ -1,0 +1,2 @@
+-- Put upgrade SQL here
+ALTER TABLE cloud_code_route ALTER COLUMN backend_url DROP DEFAULT;

--- a/pkg/gateway/config/config.go
+++ b/pkg/gateway/config/config.go
@@ -45,8 +45,7 @@ type GearURLConfig struct {
 
 // RouterConfig contain gears url
 type RouterConfig struct {
-	Auth                       GearURLConfig `envconfig:"AUTH"`
-	DefaultCloudCodeBackendURL string        `envconfig:"DEFAULT_CLOUD_CODE_BACKEND_URL"`
+	Auth GearURLConfig `envconfig:"AUTH"`
 }
 
 // GetGearURL provide router map from RouterConfig

--- a/pkg/gateway/db/pq/cloudcode.go
+++ b/pkg/gateway/db/pq/cloudcode.go
@@ -16,14 +16,14 @@ var ErrCloudCodeNotFound = errors.New("CloudCode not found")
 func (s *Store) FindLongestMatchedCloudCode(path string, app model.App, cloudCode *model.CloudCode) error {
 	logger := logging.LoggerEntry("gateway")
 	builder := psql.Select(
-		"cloud_code.id",
-		"cloud_code.created_at",
-		"cloud_code.version",
-		"cloud_code.path",
-		"cloud_code.target_path",
-		"cloud_code.backend_url",
+		"cloud_code_route.id",
+		"cloud_code_route.created_at",
+		"cloud_code_route.version",
+		"cloud_code_route.path",
+		"cloud_code_route.target_path",
+		"cloud_code_route.backend_url",
 	).
-		From(s.tableName("cloud_code")).
+		From(s.tableName("cloud_code_route")).
 		Where("? LIKE path || '%'", path).
 		Where("app_id = ?", app.ID).
 		OrderBy("length(path) desc").

--- a/pkg/gateway/handler/cloudcode.go
+++ b/pkg/gateway/handler/cloudcode.go
@@ -20,16 +20,11 @@ func newCloudCodeReverseProxy(routerConfig config.RouterConfig) *httputil.Revers
 		query := req.URL.RawQuery
 		fragment := req.URL.Fragment
 
-		backendURLStr := routerConfig.DefaultCloudCodeBackendURL
-
 		ctx := model.GatewayContextFromContext(req.Context())
 		cloudCode := ctx.CloudCode
-		if cloudCode.BackendURL != "" {
-			backendURLStr = cloudCode.BackendURL
-		}
 
 		var err error
-		backendURL, err := url.Parse(backendURLStr)
+		backendURL, err := url.Parse(cloudCode.BackendURL)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
The table name `cloud_code` duplicated with that of skygear-controller, so table renamed to `cloud_code_route` and the table only contains routing data.