### PR TITLE
Encode extra info JSON object in base64

### DIFF
--- a/pkg/core/auth/session/provider_impl.go
+++ b/pkg/core/auth/session/provider_impl.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -265,10 +266,10 @@ func newAccessEvent(timestamp gotime.Time, req *http.Request) auth.SessionAccess
 		Forwarded:     req.Header.Get("Forwarded"),
 	}
 
-	extraData := []byte(req.Header.Get(corehttp.HeaderSessionExtraInfo))
 	extra := auth.SessionAccessEventExtraInfo{}
-	if len(extraData) <= extraDataSizeLimit {
-		json.Unmarshal(extraData, &extra)
+	extraData, err := base64.StdEncoding.DecodeString(req.Header.Get(corehttp.HeaderSessionExtraInfo))
+	if err == nil && len(extraData) <= extraDataSizeLimit {
+		_ = json.Unmarshal(extraData, &extra)
 	}
 
 	return auth.SessionAccessEvent{

--- a/pkg/core/auth/session/provider_impl_test.go
+++ b/pkg/core/auth/session/provider_impl_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"testing"
@@ -34,7 +35,7 @@ func TestProvider(t *testing.T) {
 
 		req, _ := http.NewRequest("POST", "", nil)
 		req.Header.Set("User-Agent", "SDK")
-		req.Header.Set("X-Skygear-Extra-Info", `{ "device_name": "Device" }`)
+		req.Header.Set("X-Skygear-Extra-Info", "eyAiZGV2aWNlX25hbWUiOiAiRGV2aWNlIiB9")
 		accessEvent := auth.SessionAccessEvent{
 			Timestamp: initialTime,
 			UserAgent: "SDK",
@@ -373,7 +374,7 @@ func TestProvider(t *testing.T) {
 		})
 		Convey("should populate extra info", func() {
 			req, _ := http.NewRequest("POST", "", nil)
-			req.Header.Set("X-Skygear-Extra-Info", `{ "device_name": "Device" }`)
+			req.Header.Set("X-Skygear-Extra-Info", "eyAiZGV2aWNlX25hbWUiOiAiRGV2aWNlIiB9")
 
 			event := newAccessEvent(now, req)
 			So(event.Extra, ShouldResemble, auth.SessionAccessEventExtraInfo{
@@ -389,6 +390,7 @@ func TestProvider(t *testing.T) {
 				extra += fmt.Sprintf(`"info_%d": %d`, i, i)
 			}
 			extra += " }"
+			extra = base64.StdEncoding.EncodeToString([]byte(extra))
 
 			req, _ := http.NewRequest("POST", "", nil)
 			req.Header.Set("X-Skygear-Extra-Info", extra)


### PR DESCRIPTION
Non-ASCII characters in HTTP header value may have undefined behavior, and JSON may contains them.

ref #1010 