### PR TITLE
Use golang templates

### DIFF
--- a/pkg/auth/dependency/forgotpwdemail/testsender.go
+++ b/pkg/auth/dependency/forgotpwdemail/testsender.go
@@ -71,12 +71,12 @@ func (d *DefaultTestSender) Send(
 	}
 
 	var textBody string
-	if textBody, err = template.ParseTextTemplate(textTemplate, context); err != nil {
+	if textBody, err = template.ParseTextTemplate("test-text", textTemplate, context); err != nil {
 		return
 	}
 
 	var htmlBody string
-	if htmlBody, err = template.ParseHTMLTemplate(htmlTemplate, context); err != nil {
+	if htmlBody, err = template.ParseHTMLTemplate("test-html", htmlTemplate, context); err != nil {
 		return
 	}
 

--- a/pkg/auth/dependency/sso/auth_handler_html.go
+++ b/pkg/auth/dependency/sso/auth_handler_html.go
@@ -98,7 +98,7 @@ req.onload = function() {
 		throw new Error("no window.opener");
 	}
 };
-req.open("POST", "{{ api_endpoint }}/_auth/sso/config", true);
+req.open("POST", "{{ .api_endpoint }}/_auth/sso/config", true);
 req.send(null);
 </script>
 </head>
@@ -110,5 +110,5 @@ req.send(null);
 		"api_endpoint": i.APIEndPoint,
 	}
 
-	return template.ParseHTMLTemplate(templateString, context)
+	return template.ParseHTMLTemplate("auth_handler", templateString, context)
 }

--- a/pkg/auth/dependency/sso/iframe_html.go
+++ b/pkg/auth/dependency/sso/iframe_html.go
@@ -94,7 +94,7 @@ req.onload = function() {
 	var authorizedURLs = jsonResponse.result.authorized_urls;
 	postSSOResultMessageToWindow(window.parent, authorizedURLs);
 };
-req.open("POST", "{{ api_endpoint }}/_auth/sso/config", true);
+req.open("POST", "{{ .api_endpoint }}/_auth/sso/config", true);
 req.send(null);
 </script>
 </head>
@@ -106,5 +106,5 @@ req.send(null);
 		"api_endpoint": i.APIEndPoint,
 	}
 
-	return template.ParseHTMLTemplate(templateString, context)
+	return template.ParseHTMLTemplate("iframe_html", templateString, context)
 }

--- a/pkg/auth/dependency/welcemail/testsender.go
+++ b/pkg/auth/dependency/welcemail/testsender.go
@@ -60,12 +60,12 @@ func (d *DefaultTestSender) Send(
 	}
 
 	var textBody string
-	if textBody, err = template.ParseTextTemplate(textTemplate, context); err != nil {
+	if textBody, err = template.ParseTextTemplate("test-text", textTemplate, context); err != nil {
 		return
 	}
 
 	var htmlBody string
-	if htmlBody, err = template.ParseHTMLTemplate(htmlTemplate, context); err != nil {
+	if htmlBody, err = template.ParseHTMLTemplate("test-html", htmlTemplate, context); err != nil {
 		return
 	}
 

--- a/pkg/auth/handler/sso/auth_handler_test.go
+++ b/pkg/auth/handler/sso/auth_handler_test.go
@@ -281,7 +281,7 @@ func TestAuthHandler(t *testing.T) {
 			sh.ServeHTTP(resp, req)
 			// for web_redirect, it should redirect to original callback url
 			So(resp.Code, ShouldEqual, 200)
-			apiEndpointPattern := `"https://api.example.com/_auth/sso/config"`
+			apiEndpointPattern := `"https:\\/\\/api.example.com/_auth/sso/config"`
 			matched, err := regexp.MatchString(apiEndpointPattern, resp.Body.String())
 			So(err, ShouldBeNil)
 			So(matched, ShouldBeTrue)

--- a/pkg/auth/handler/sso/iframe_handler_test.go
+++ b/pkg/auth/handler/sso/iframe_handler_test.go
@@ -22,7 +22,7 @@ func TestIFrameHandler(t *testing.T) {
 			resp := httptest.NewRecorder()
 			ih.ServeHTTP(resp, req)
 
-			apiEndpointPattern := `"https://api.example.com/_auth/sso/config"`
+			apiEndpointPattern := `"https:\\/\\/api.example.com/_auth/sso/config"`
 			matched, err := regexp.MatchString(apiEndpointPattern, resp.Body.String())
 
 			So(err, ShouldBeNil)

--- a/pkg/auth/template/forgot_password_email_txt.go
+++ b/pkg/auth/template/forgot_password_email_txt.go
@@ -1,11 +1,11 @@
 package template
 
 /* #nosec */
-const templateForgotPasswordEmailTxt = `Dear {{ email }},
+const templateForgotPasswordEmailTxt = `Dear {{ .email }},
 
-You received this email because someone tries to reset your account password on {{ appname }}. To reset your account password, click this link:
+You received this email because someone tries to reset your account password on {{ .appname }}. To reset your account password, click this link:
 
-{{ link }}
+{{ .link }}
 
 If you did not request to reset your account password, Please ignore this email.
 

--- a/pkg/auth/template/mfa.go
+++ b/pkg/auth/template/mfa.go
@@ -1,12 +1,12 @@
 package template
 
-const templateMFAOOBCodeSMSText = `Your MFA code is: {{ code }}`
-const templateMFAOOBCodeEmailText = `Your MFA code is: {{ code }}`
+const templateMFAOOBCodeSMSText = `Your MFA code is: {{ .code }}`
+const templateMFAOOBCodeEmailText = `Your MFA code is: {{ .code }}`
 const templateMFAOOBCodeEmailHTML = `<!DOCTYPE html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
-<p>Your MFA code is: {{ code }}</p>
+<p>Your MFA code is: {{ .code }}</p>
 </body>
 `

--- a/pkg/auth/template/reset_password_error_html.go
+++ b/pkg/auth/template/reset_password_error_html.go
@@ -6,4 +6,4 @@ const templateResetPasswordErrorHTML = `<!DOCTYPE html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
-<p>{{ error }}</p>`
+<p>{{ .error }}</p>`

--- a/pkg/auth/template/reset_password_html.go
+++ b/pkg/auth/template/reset_password_html.go
@@ -6,16 +6,16 @@ const templateResetPasswordHTML = `<!DOCTYPE html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
-{% if error %}
-<p>{{ error }}</p>
-{% endif %}
-<form method="POST" action="{{ action_url }}">
+{{ if .error }}
+<p>{{ .error }}</p>
+{{ end }}
+<form method="POST" action="{{ .action_url }}">
   <label for="password">New Password</label>
   <input type="password" name="password"><br>
   <label for="confirm">Confirm Password</label>
   <input type="password" name="confirm"><br>
-  <input type="hidden" name="code" value="{{ code }}">
-  <input type="hidden" name="user_id" value="{{ user_id }}">
-  <input type="hidden" name="expire_at" value="{{ expire_at }}">
+  <input type="hidden" name="code" value="{{ .code }}">
+  <input type="hidden" name="user_id" value="{{ .user_id }}">
+  <input type="hidden" name="expire_at" value="{{ .expire_at }}">
   <input type="submit" value="Submit">
 </form>`

--- a/pkg/auth/template/verify_email_txt.go
+++ b/pkg/auth/template/verify_email_txt.go
@@ -1,10 +1,10 @@
 package template
 
-var templateVerifyEmailTxt = `Dear {{ login_id }},
+var templateVerifyEmailTxt = `Dear {{ .login_id }},
 
-You received this email because {{ appname }} would like to verify your email address. If you have recently signed up for this app or if you have recently made changes to your account, click the following link:
+You received this email because {{ .appname }} would like to verify your email address. If you have recently signed up for this app or if you have recently made changes to your account, click the following link:
 
-{{ link }}
+{{ .link }}
 
 If you are unsure why you received this email, please ignore this email and you do not need to take any action.
 

--- a/pkg/auth/template/verify_error_html.go
+++ b/pkg/auth/template/verify_error_html.go
@@ -4,4 +4,4 @@ const templateVerifyErrorHTML = `<!DOCTYPE html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
-<p>{{ error }}</p>`
+<p>{{ .error }}</p>`

--- a/pkg/auth/template/verify_sms_txt.go
+++ b/pkg/auth/template/verify_sms_txt.go
@@ -1,3 +1,3 @@
 package template
 
-var templateVerifySMSTxt = `Your {{ appname }} Verification Code is: {{ code }}`
+var templateVerifySMSTxt = `Your {{ .appname }} Verification Code is: {{ .code }}`

--- a/pkg/auth/template/welcome_email_txt.go
+++ b/pkg/auth/template/welcome_email_txt.go
@@ -1,6 +1,6 @@
 package template
 
-const templateWelcomeEmailTxt = `Hello {{ email }},
+const templateWelcomeEmailTxt = `Hello {{ .email }},
 
 Welcome to Skygear.
 

--- a/pkg/core/middleware/authn.go
+++ b/pkg/core/middleware/authn.go
@@ -51,7 +51,7 @@ func (m *AuthnMiddleware) Handle(next http.Handler) http.Handler {
 				// Clear session if session is not found
 				m.SessionWriter.ClearSession(w)
 			} else if err != nil {
-				log.WithError(err).Debug("Cannot resolve session")
+				log.WithError(err).Error("Cannot resolve session")
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/pkg/core/template/engine.go
+++ b/pkg/core/template/engine.go
@@ -49,7 +49,7 @@ func (e *Engine) ParseTextTemplate(templateName string, context map[string]inter
 		return
 	}
 
-	return ParseTextTemplate(templateBody, context)
+	return ParseTextTemplate(templateName, templateBody, context)
 }
 
 func (e *Engine) ParseHTMLTemplate(templateName string, context map[string]interface{}, option ParseOption) (out string, err error) {
@@ -58,7 +58,7 @@ func (e *Engine) ParseHTMLTemplate(templateName string, context map[string]inter
 		return
 	}
 
-	return ParseHTMLTemplate(templateBody, context)
+	return ParseHTMLTemplate(templateName, templateBody, context)
 }
 
 func (e *Engine) downloadContent(templateName string, option ParseOption) (templateBody string, err error) {

--- a/pkg/core/template/template_test.go
+++ b/pkg/core/template/template_test.go
@@ -11,12 +11,12 @@ import (
 func TestTemplateRender(t *testing.T) {
 	Convey("template rendering", t, func() {
 		Convey("should not render large templates", func() {
-			longStr := strings.Repeat("\\", 1024*512)
-			template := fmt.Sprintf(`{{if $v := "%s" | js}}{{$v|js}}{{$v|js}}{{$v|js}}{{$v|js}}{{end}}`, longStr)
+			longStr := strings.Repeat("&", MaxTemplateSize - 25)
+			template := fmt.Sprintf(`{{"%s"|html|html|html}}`, longStr)
 
 			var err error
 
-			_, err = ParseHTMLTemplate("test", template, nil)
+			_, err = ParseTextTemplate("test", template, nil)
 			So(err, ShouldBeError, "UnexpectedError: rendered template is too large")
 		})
 	})

--- a/pkg/core/template/template_test.go
+++ b/pkg/core/template/template_test.go
@@ -1,6 +1,8 @@
 package template
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -8,16 +10,13 @@ import (
 
 func TestTemplateRender(t *testing.T) {
 	Convey("template rendering", t, func() {
-		Convey("should not allow disabled tags", func() {
-			var err error
-
-			_, err = ParseHTMLTemplate("{% include /etc/passwd %}", nil)
-			So(err, ShouldBeError, "[Error (where: parser) in <string> | Line 1 Col 4 near 'include'] Usage of tag 'include' is not allowed (sandbox restriction active).")
-		})
 		Convey("should not render large templates", func() {
+			longStr := strings.Repeat("\\", 1024*512)
+			template := fmt.Sprintf(`{{if $v := "%s" | js}}{{$v|js}}{{$v|js}}{{$v|js}}{{$v|js}}{{end}}`, longStr)
+
 			var err error
 
-			_, err = ParseHTMLTemplate(`{%for i in "0123456789abcdef"%}{%for i in "0123456789abcdef"%}{%for i in "0123456789abcdef"%}{%for i in "0123456789abcdef"%}{%for i in "0123456789abcdef"%}{%for i in "0123456789abcdef"%}{%for i in "0123456789abcdef"%}{%for i in "0123456789abcdef"%}{%for i in "0123456789abcdef"%}0123456789abcdef{%endfor%}{%endfor%}{%endfor%}{%endfor%}{%endfor%}{%endfor%}{%endfor%}{%endfor%}{%endfor%}`, nil)
+			_, err = ParseHTMLTemplate("test", template, nil)
 			So(err, ShouldBeError, "UnexpectedError: rendered template is too large")
 		})
 	})

--- a/pkg/core/template/template_test.go
+++ b/pkg/core/template/template_test.go
@@ -11,7 +11,7 @@ import (
 func TestTemplateRender(t *testing.T) {
 	Convey("template rendering", t, func() {
 		Convey("should not render large templates", func() {
-			longStr := strings.Repeat("&", MaxTemplateSize - 50)
+			longStr := strings.Repeat("&", MaxTemplateSize-50)
 			template := fmt.Sprintf(`{{html (html (html (html "%s")))}}`, longStr)
 
 			var err error

--- a/pkg/core/template/template_test.go
+++ b/pkg/core/template/template_test.go
@@ -11,8 +11,8 @@ import (
 func TestTemplateRender(t *testing.T) {
 	Convey("template rendering", t, func() {
 		Convey("should not render large templates", func() {
-			longStr := strings.Repeat("&", MaxTemplateSize - 25)
-			template := fmt.Sprintf(`{{"%s"|html|html|html}}`, longStr)
+			longStr := strings.Repeat("&", MaxTemplateSize - 50)
+			template := fmt.Sprintf(`{{html (html (html (html "%s")))}}`, longStr)
 
 			var err error
 

--- a/pkg/core/template/validation.go
+++ b/pkg/core/template/validation.go
@@ -45,7 +45,9 @@ func validateTree(tree *parse.Tree) (err error) {
 			case *parse.IfNode, *parse.ListNode, *parse.ActionNode, *parse.TextNode:
 				break
 			case *parse.PipeNode:
-				if len(n.Cmds) > 4 {
+				if len(n.Decl) > 0 {
+					err = fmt.Errorf("template: %s: declaration is forbidden", formatLocation(tree, n))
+				} else if len(n.Cmds) > 4 {
 					err = fmt.Errorf("template: %s: pipeline is too long", formatLocation(tree, n))
 				}
 			case *parse.CommandNode:

--- a/pkg/core/template/validation.go
+++ b/pkg/core/template/validation.go
@@ -70,7 +70,9 @@ func validateTree(tree *parse.Tree) (err error) {
 }
 
 var badIdentifiers = []string{
+	"print",
 	"printf",
+	"println",
 }
 
 func checkIdentifier(id string) bool {

--- a/pkg/core/template/validation.go
+++ b/pkg/core/template/validation.go
@@ -1,0 +1,149 @@
+package template
+
+import (
+	"fmt"
+	html "html/template"
+	"sort"
+	text "text/template"
+	"text/template/parse"
+)
+
+func ValidateTextTemplate(template *text.Template) error {
+	tpls := template.Templates()
+	sort.Slice(tpls, func(i, j int) bool {
+		return tpls[i].Name() < tpls[j].Name()
+	})
+
+	for _, tpl := range tpls {
+		if err := validateTree(tpl.Tree); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ValidateHTMLTemplate(template *html.Template) error {
+	tpls := template.Templates()
+	sort.Slice(tpls, func(i, j int) bool {
+		return tpls[i].Name() < tpls[j].Name()
+	})
+
+	for _, tpl := range tpls {
+		if err := validateTree(tpl.Tree); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateTree(tree *parse.Tree) (err error) {
+	validateFn := func(n parse.Node, depth int) (cont bool) {
+		if depth > 4 {
+			err = fmt.Errorf("template: %s: template nested too deep", formatLocation(tree, n))
+		} else {
+			switch n := n.(type) {
+			case *parse.IfNode, *parse.ListNode, *parse.ActionNode, *parse.TextNode:
+				break
+			case *parse.PipeNode:
+				if len(n.Cmds) > 4 {
+					err = fmt.Errorf("template: %s: pipeline is too long", formatLocation(tree, n))
+				}
+			case *parse.CommandNode:
+				for _, arg := range n.Args {
+					if ident, ok := arg.(*parse.IdentifierNode); ok {
+						if !checkIdentifier(ident.Ident) {
+							err = fmt.Errorf("template: %s: forbidden identifier %s", formatLocation(tree, n), ident.Ident)
+							break
+						}
+					}
+				}
+			default:
+				err = fmt.Errorf("template: %s: forbidden construct %T", formatLocation(tree, n), n)
+			}
+		}
+
+		return err == nil
+	}
+
+	traverseTree(tree, validateFn)
+	return
+}
+
+var badIdentifiers = []string{
+	"printf",
+}
+
+func checkIdentifier(id string) bool {
+	for _, badId := range badIdentifiers {
+		if id == badId {
+			return false
+		}
+	}
+	return true
+}
+
+func formatLocation(tree *parse.Tree, n parse.Node) string {
+	location, _ := tree.ErrorContext(n)
+	return location
+}
+
+func traverseTree(tree *parse.Tree, fn func(n parse.Node, depth int) (cont bool)) {
+	var visit func(n parse.Node, depth int) (cont bool)
+	visitBranch := func(n *parse.BranchNode, depth int) (cont bool) {
+		if cont = visit(n.Pipe, depth); !cont {
+			return
+		}
+		if cont = visit(n.List, depth); !cont {
+			return
+		}
+		if n.ElseList != nil {
+			if cont = visit(n.ElseList, depth); !cont {
+				return false
+			}
+		}
+		return
+	}
+	visit = func(n parse.Node, depth int) (cont bool) {
+		cont = fn(n, depth)
+		if !cont {
+			return
+		}
+
+		switch n := n.(type) {
+		case *parse.IfNode:
+			cont = visitBranch(&n.BranchNode, depth)
+		case *parse.RangeNode:
+			cont = visitBranch(&n.BranchNode, depth)
+		case *parse.WithNode:
+			cont = visitBranch(&n.BranchNode, depth)
+		case *parse.ListNode:
+			for _, n := range n.Nodes {
+				if cont = visit(n, depth+1); !cont {
+					break
+				}
+			}
+		case *parse.ActionNode:
+			cont = visit(n.Pipe, depth)
+		case *parse.PipeNode:
+			for _, cmd := range n.Cmds {
+				if cont = visit(cmd, depth); !cont {
+					break
+				}
+			}
+		case *parse.CommandNode:
+			for _, arg := range n.Args {
+				if pipe, ok := arg.(*parse.PipeNode); ok {
+					if cont = visit(pipe, depth+1); !cont {
+						break
+					}
+				}
+			}
+		case *parse.TemplateNode, *parse.TextNode:
+			break
+		default:
+			panic("unknown node type")
+		}
+		return
+	}
+	visit(tree.Root, 0)
+}

--- a/pkg/core/template/validation.go
+++ b/pkg/core/template/validation.go
@@ -47,8 +47,8 @@ func validateTree(tree *parse.Tree) (err error) {
 			case *parse.PipeNode:
 				if len(n.Decl) > 0 {
 					err = fmt.Errorf("template: %s: declaration is forbidden", formatLocation(tree, n))
-				} else if len(n.Cmds) > 4 {
-					err = fmt.Errorf("template: %s: pipeline is too long", formatLocation(tree, n))
+				} else if len(n.Cmds) > 1 {
+					err = fmt.Errorf("template: %s: pipeline is forbidden", formatLocation(tree, n))
 				}
 			case *parse.CommandNode:
 				for _, arg := range n.Args {

--- a/pkg/core/template/validation.go
+++ b/pkg/core/template/validation.go
@@ -78,8 +78,8 @@ var badIdentifiers = []string{
 }
 
 func checkIdentifier(id string) bool {
-	for _, badId := range badIdentifiers {
-		if id == badId {
+	for _, badID := range badIdentifiers {
+		if id == badID {
 			return false
 		}
 	}

--- a/pkg/core/template/validation_test.go
+++ b/pkg/core/template/validation_test.go
@@ -1,0 +1,80 @@
+package template
+
+import (
+	"html/template"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestTemplateValidation(t *testing.T) {
+	Convey("template validation", t, func() {
+		template := func(s string) *template.Template {
+			return template.Must(template.New("email").Parse(s))
+		}
+
+		Convey("should allow good templates", func() {
+			var err error
+
+			err = ValidateHTMLTemplate(template(`{{ if ne .UserName "" }}Welcome, {{ .UserName }}{{ else }}Please login{{ end }}`))
+			So(err, ShouldBeNil)
+		})
+
+		Convey("should not allow disabled constructs", func() {
+			var err error
+
+			err = ValidateHTMLTemplate(template(`{{ range $i, $e := . }}{{$i}}{{$e}}{{ end }}`))
+			So(err, ShouldBeError, "template: email:1:9: forbidden construct *parse.RangeNode")
+
+			err = ValidateHTMLTemplate(template(`{{block "name" ""}} Test {{ template "name" }} {{end}}`))
+			So(err, ShouldBeError, "template: email:1:8: forbidden construct *parse.TemplateNode")
+
+			err = ValidateHTMLTemplate(template(`
+			{{ with $v := js "\\" }}
+				{{ with $v := js $v }}
+					{{ with $v := js $v }}
+						{{ with $v := js $v }}
+							{{$v}}
+						{{end}}
+					{{end}}
+				{{end}}
+			{{end}}`))
+			So(err, ShouldBeError, "template: email:2:11: forbidden construct *parse.WithNode")
+		})
+
+		Convey("should not allow disabled functions", func() {
+			var err error
+
+			err = ValidateHTMLTemplate(template(`{{printf "%010000000d" 0}}`))
+			So(err, ShouldBeError, "template: email:1:2: forbidden identifier printf")
+		})
+
+		Convey("should not allow nesting too deep", func() {
+			var err error
+
+			err = ValidateHTMLTemplate(template(`{{ "\\" | js | js | js }}`))
+			So(err, ShouldBeNil)
+
+			err = ValidateHTMLTemplate(template(`{{ "\\" | js | js | js | js }}`))
+			So(err, ShouldBeError, "template: email:1:3: pipeline is too long")
+
+			err = ValidateHTMLTemplate(template(`{{ js (js (js (js "\\"))) }}`))
+			So(err, ShouldBeNil)
+
+			err = ValidateHTMLTemplate(template(`{{ js (js (js (js (js "\\")))) }}`))
+			So(err, ShouldBeError, "template: email:1:19: template nested too deep")
+
+			err = ValidateHTMLTemplate(template(`
+			{{ if $v := js "\\" }}
+				{{ if $v := js $v }}
+					{{ if $v := js $v }}
+						{{ if $v := js $v }}
+							{{$v}}
+						{{end}}
+					{{end}}
+				{{end}}
+			{{end}}`))
+			So(err, ShouldBeError, "template: email:5:26: template nested too deep")
+		})
+	})
+}

--- a/pkg/core/template/validation_test.go
+++ b/pkg/core/template/validation_test.go
@@ -65,11 +65,8 @@ func TestTemplateValidation(t *testing.T) {
 		Convey("should not allow nesting too deep", func() {
 			var err error
 
-			err = ValidateHTMLTemplate(template(`{{ "\\" | js | js | js }}`))
-			So(err, ShouldBeNil)
-
-			err = ValidateHTMLTemplate(template(`{{ "\\" | js | js | js | js }}`))
-			So(err, ShouldBeError, "template: email:1:3: pipeline is too long")
+			err = ValidateHTMLTemplate(template(`{{ js (js (js "\\" | js | js | js) | js | js | js) | js | js | js }}`))
+			So(err, ShouldBeError, "template: email:1:3: pipeline is forbidden")
 
 			err = ValidateHTMLTemplate(template(`{{ js (js (js (js "\\"))) }}`))
 			So(err, ShouldBeNil)

--- a/template/verify_error.html
+++ b/template/verify_error.html
@@ -3,4 +3,4 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
-<p>{{ error }}</p>
+<p>{{ .error }}</p>


### PR DESCRIPTION
ref #1055 

also fix #1056 

note: my limited testing shows that in the worst case, a 1MB malicious template could consume ~17MB memory during rendering due to escaping function. do we want to disable escaping functions, and enforce auto-escaping instead?