### PR TITLE
Fix incorrect timing for setting CORS headers

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -136,6 +136,9 @@ func main() {
 		Store:              store,
 	}.Handle)
 
+	// CORS headers should be set right after a proxy backend has been found.
+	cr.Use(coreMiddleware.CORSMiddleware{}.Handle)
+
 	cr.Use(coreMiddleware.Injecter{
 		MiddlewareFactory: coreMiddleware.AuthnMiddlewareFactory{},
 		Dependency:        gatewayDependency,
@@ -145,8 +148,6 @@ func main() {
 		MiddlewareFactory: middleware.AuthInfoMiddlewareFactory{},
 		Dependency:        gatewayDependency,
 	}.Handle)
-
-	cr.Use(coreMiddleware.CORSMiddleware{}.Handle)
 
 	cr.HandleFunc("/{rest:.*}", handler.NewDeploymentRouteHandler())
 


### PR DESCRIPTION
CORS header should be set as soon as possible (i.e. a proxy backend has been matched), so that client can read the potential errors in response headers/body.

fix #1078 