### PR TITLE
Update asset gear config & behavior

### DIFF
--- a/cmd/asset/main.go
+++ b/cmd/asset/main.go
@@ -81,6 +81,7 @@ func main() {
 		storage = cloudstorage.NewS3Storage(
 			configuration.Storage.S3.AccessKey,
 			configuration.Storage.S3.SecretKey,
+			configuration.Storage.S3.Endpoint,
 			configuration.Storage.S3.Region,
 			configuration.Storage.S3.Bucket,
 		)

--- a/pkg/asset/config/config.go
+++ b/pkg/asset/config/config.go
@@ -46,6 +46,7 @@ type GCSConfiguration struct {
 }
 
 type S3Configuration struct {
+	Endpoint  string `envconfig:"ENDPOINT"`
 	Region    string `envconfig:"REGION"`
 	Bucket    string `envconfig:"BUCKET"`
 	AccessKey string `envconfig:"ACCESS_KEY"`

--- a/pkg/asset/handler/get.go
+++ b/pkg/asset/handler/get.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 
 	"github.com/gorilla/mux"
 
@@ -112,6 +113,13 @@ func (h *GetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// We only know how to modify 2xx response.
 		if resp.StatusCode < 200 || resp.StatusCode > 299 {
 			return nil
+		}
+
+		// Remove existing CORS header in response
+		for name := range w.Header() {
+			if strings.HasPrefix(name, "Access-Control-") {
+				w.Header().Del(name)
+			}
 		}
 
 		resp.Header = h.CloudStorageProvider.ProprietaryToStandard(resp.Header)

--- a/pkg/core/cloudstorage/s3.go
+++ b/pkg/core/cloudstorage/s3.go
@@ -50,13 +50,16 @@ var S3StandardToProprietaryMap = map[string]string{
 	"access-control-allow-headers":     "x-amz-meta-accesscontrolallowheaders",
 }
 
-func NewS3Storage(accessKey string, secretKey string, region string, bucket string) *S3Storage {
+func NewS3Storage(accessKey, secretKey, endpoint, region, bucket string) *S3Storage {
 	cred := credentials.NewStaticCredentials(accessKey, secretKey, "")
+	usePathStyle := endpoint != "" // for minio compatibility
 	// FIXME(cloudstorage): Use session.NewSession instead of session.New
 	// nolint: staticcheck
 	sess := session.New(&aws.Config{
-		Credentials: cred,
-		Region:      aws.String(region),
+		Credentials:      cred,
+		Region:           aws.String(region),
+		Endpoint:         &endpoint,
+		S3ForcePathStyle: &usePathStyle,
 	})
 	s3 := s3.New(sess)
 


### PR DESCRIPTION
For local development purpose, it is easier to setup a minio server and use S3 backend of asset gear.

Also, when CORS headers is returned by storage backend, we should pass-through these headers directly in the reverse proxy. For asset gear in standalone mode, removing headers added by middleware would be enough. However for asset gear behind gateway, we'll need some way to instruct gateway to pass-through the CORS headers from asset gear (TODO).
