### PR TITLE
Fix signup verification email

### DIFF
--- a/pkg/core/async/executor.go
+++ b/pkg/core/async/executor.go
@@ -54,6 +54,12 @@ func (e *Executor) Execute(taskCtx TaskContext, name string, param interface{}, 
 		}()
 
 		err := task.Run(param)
+		if err != nil {
+			logger.WithFields(map[string]interface{}{
+				"task_name": name,
+				"error":     err,
+			}).Error("error occurred when running async task")
+		}
 		if response != nil {
 			response <- err
 		}


### PR DESCRIPTION
connect #1142 

Signup handler enqueue the tasks before db transaction commit. And `VerifyCodeSendTask` will query the db for the user data, so the task may fail randomly due to user not found error. This PR updates the flow to enqueue tasks after db commit. We may have similar problems in another handlers, will check and open another PR if needed.