### PR TITLE
Adjust static asset gateway proxying

### DIFF
--- a/pkg/core/http/cors.go
+++ b/pkg/core/http/cors.go
@@ -41,6 +41,8 @@ func FixupCORSHeaders(downstream http.ResponseWriter, upstream *http.Response) {
 
 	// Upstream has provided CORS header; upstream will manage all CORS headers
 	// Remove existing CORS headers from response to downstream
+	// `Vary: Origin` is also used to control CORS policy, so upstream
+	// should manage it themselves.
 	headers := downstream.Header()
 	for name, values := range headers {
 		if strings.HasPrefix(name, "Access-Control-") {

--- a/pkg/core/http/cors.go
+++ b/pkg/core/http/cors.go
@@ -5,12 +5,33 @@ import (
 	"strings"
 )
 
+func parseVaryHeaders(values []string) []string {
+	var headers []string
+	for _, v := range values {
+		for _, h := range strings.Split(v, ",") {
+			h = strings.TrimSpace(h)
+			if h != "" {
+				headers = append(headers, h)
+			}
+		}
+	}
+	return headers
+}
+
 func FixupCORSHeaders(downstream http.ResponseWriter, upstream *http.Response) {
 	hasCORSHeaders := false
-	for name := range upstream.Header {
+	for name, values := range upstream.Header {
 		if strings.HasPrefix(name, "Access-Control-") {
 			hasCORSHeaders = true
 			break
+		}
+		if name == "Vary" {
+			varyHeaders := parseVaryHeaders(values)
+			for _, h := range varyHeaders {
+				if http.CanonicalHeaderKey(h) == "Origin" {
+					hasCORSHeaders = true
+				}
+			}
 		}
 	}
 
@@ -21,9 +42,26 @@ func FixupCORSHeaders(downstream http.ResponseWriter, upstream *http.Response) {
 	// Upstream has provided CORS header; upstream will manage all CORS headers
 	// Remove existing CORS headers from response to downstream
 	headers := downstream.Header()
-	for name := range headers {
+	for name, values := range headers {
 		if strings.HasPrefix(name, "Access-Control-") {
 			headers.Del(name)
+		}
+		// Delete 'Vary: Origin' header
+		if name == "Vary" {
+			varyHeaders := parseVaryHeaders(values)
+			n := 0
+			for _, h := range varyHeaders {
+				if http.CanonicalHeaderKey(h) != "Origin" {
+					varyHeaders[n] = h
+					n++
+				}
+			}
+			varyHeaders = varyHeaders[:n]
+			if len(varyHeaders) > 0 {
+				headers[name] = []string{strings.Join(varyHeaders, ",")}
+			} else {
+				delete(headers, name)
+			}
 		}
 	}
 }

--- a/pkg/core/http/cors_test.go
+++ b/pkg/core/http/cors_test.go
@@ -1,0 +1,50 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestFixupCORSHeaders(t *testing.T) {
+	Convey("FixupCORSHeaders", t, func() {
+		Convey("return CORS headers to downstream", func() {
+			downstream := httptest.NewRecorder()
+			downstream.Header().Set("Vary", "Origin, Authorization")
+			downstream.Header().Set("Access-Control-Allow-Origin", "*")
+			downstream.Header().Set("Request-Id", "12345678")
+
+			upstream := &http.Response{Header: http.Header{}}
+			upstream.Header.Set("Accept", "application/json")
+			upstream.Header.Set("Vary", "Accept")
+
+			FixupCORSHeaders(downstream, upstream)
+
+			So(downstream.Result().Header, ShouldResemble, http.Header{
+				"Vary":                        []string{"Origin, Authorization"},
+				"Access-Control-Allow-Origin": []string{"*"},
+				"Request-Id":                  []string{"12345678"},
+			})
+		})
+		Convey("allow upstream to manage CORS headers", func() {
+			downstream := httptest.NewRecorder()
+			downstream.Header().Set("Vary", "Origin, Authorization")
+			downstream.Header().Set("Access-Control-Allow-Origin", "*")
+			downstream.Header().Set("Request-Id", "12345678")
+
+			upstream := &http.Response{Header: http.Header{}}
+			upstream.Header.Set("Accept", "application/json")
+			upstream.Header.Set("Vary", "Accept, Origin")
+			upstream.Header.Set("Access-Control-Allow-Origin", "example.com")
+
+			FixupCORSHeaders(downstream, upstream)
+
+			So(downstream.Result().Header, ShouldResemble, http.Header{
+				"Vary":       []string{"Authorization"},
+				"Request-Id": []string{"12345678"},
+			})
+		})
+	})
+}


### PR DESCRIPTION
Static assets goes through many services:
```
Client -> Gateway (static asset) -> Gateway (asset gear) -> Asset Gear
```

Before this fix, some duplicated headers can be observed:
- Request ID (x2)
- Vary: Origin (x3)
