### PR TITLE
Update travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ deploy:
     skip_cleanup: true
     on:
       repo: SkygearIO/skygear-server
-      branch: next
+      branch: master
       go: 1.13.3
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,6 @@ script:
   - make test
 
 deploy:
-  - provider: releases
-    api-key: "$GITHUB_RELEASE_TOKEN"
-    skip_cleanup: true
-    on:
-      repo: SkygearIO/skygear-server
-      tags: true
-      go: 1.13.3
   - provider: script
     script: ./scripts/deploy-docker-hub.sh
     skip_cleanup: true


### PR DESCRIPTION
- Remove release step in travis deployment
    - We used this to submit binary to github release page, we don't need this in next
- Run deploy github page in master branch