### PR TITLE
Increase sentinel dial connection time out

### DIFF
--- a/pkg/core/redis/pool.go
+++ b/pkg/core/redis/pool.go
@@ -73,11 +73,12 @@ func newSentinelPool(config Configuration) *redis.Pool {
 		Addrs:      config.Sentinel.Addrs,
 		MasterName: config.Sentinel.MasterName,
 		Dial: func(addr string) (redis.Conn, error) {
+			dialConnectTimeout := 3 * time.Second
 			timeout := 500 * time.Millisecond
 			c, err := redis.Dial(
 				"tcp",
 				addr,
-				redis.DialConnectTimeout(timeout),
+				redis.DialConnectTimeout(dialConnectTimeout),
 				redis.DialReadTimeout(timeout),
 				redis.DialWriteTimeout(timeout),
 			)


### PR DESCRIPTION
refs #1206 

In azure cluster, it often happens that server failed to connect to sentinels due to timeout. 