### PR TITLE
Update resolve gear path prefix fallback to known gears only

### DIFF
--- a/pkg/gateway/middleware/app.go
+++ b/pkg/gateway/middleware/app.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/skygeario/skygear-server/pkg/core/config"
@@ -12,8 +11,6 @@ import (
 	"github.com/skygeario/skygear-server/pkg/gateway/model"
 	"github.com/skygeario/skygear-server/pkg/gateway/store"
 )
-
-var gearPathRegex = regexp.MustCompile(`^/_([^\/]*)`)
 
 type FindAppMiddleware struct {
 	Store store.GatewayStore
@@ -116,7 +113,7 @@ func getGearToRoute(domain *model.Domain, r *http.Request) model.Gear {
 		if host == domain.Domain {
 			// microservices
 			// fallback route to gear if necessary
-			return model.Gear(getGearName(r.URL.Path))
+			return model.GetGearByPath(r.URL.Path)
 		}
 		// get gear from host
 		parts := strings.Split(host, ".")
@@ -125,16 +122,7 @@ func getGearToRoute(domain *model.Domain, r *http.Request) model.Gear {
 	if domain.Assignment == model.AssignmentTypeMicroservices {
 		// fallback route to gear by path
 		// return empty string if it is not matched
-		return model.Gear(getGearName(r.URL.Path))
+		return model.GetGearByPath(r.URL.Path)
 	}
 	return model.Gear(domain.Assignment)
-}
-
-func getGearName(path string) string {
-	result := gearPathRegex.FindStringSubmatch(path)
-	if len(result) == 2 {
-		return result[1]
-	}
-
-	return ""
 }

--- a/pkg/gateway/middleware/app_test.go
+++ b/pkg/gateway/middleware/app_test.go
@@ -62,26 +62,3 @@ func TestGetDomain(t *testing.T) {
 		})
 	})
 }
-
-func TestGetGearName(t *testing.T) {
-	Convey("GetGearName", t, func() {
-		Convey("should return gear name from path", func() {
-			cases := []struct {
-				path string
-				gear string
-			}{
-				{"/_auth", "auth"},
-				{"/_auth/login/", "auth"},
-				{"/auth/", ""},
-				{"/_auth////", "auth"},
-				{"/_asset/", "asset"},
-				{"/index", ""},
-				{"", ""},
-			}
-
-			for _, c := range cases {
-				So(getGearName(c.path), ShouldEqual, c.gear)
-			}
-		})
-	})
-}

--- a/pkg/gateway/model/app.go
+++ b/pkg/gateway/model/app.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"strings"
+
 	"github.com/skygeario/skygear-server/pkg/core/config"
 )
 
@@ -19,6 +21,11 @@ const (
 	AssetGearSubdomain GearSubdomain = "assets"
 )
 
+var PathPrefixToGear = map[string]Gear{
+	"/_auth/":  AuthGear,
+	"/_asset/": AssetGear,
+}
+
 // GetGear translate the subdomain to gear if necessary
 // otherwise return the original string
 func GetGear(subdomain string) Gear {
@@ -30,6 +37,15 @@ func GetGear(subdomain string) Gear {
 	}
 
 	return Gear(subdomain)
+}
+
+func GetGearByPath(path string) Gear {
+	for prefix, gear := range PathPrefixToGear {
+		if strings.HasPrefix(path, prefix) {
+			return gear
+		}
+	}
+	return ""
 }
 
 type GearVersion string


### PR DESCRIPTION
Originally we reserved path `/_{gear}` for gears.
This update change to route known path only, so only _auth and _asset will be routed to auth and asset gear corresponding.
For the other path that start with `/_`, we will check the deployment route.
We need this update for controller, so that we can add deployment route for controller.