### PR TITLE
Fix some Auth UI Web App bugs

### DIFF
--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -241,6 +241,7 @@ func main() {
 	webappRouter = rootRouter.NewRoute().Subrouter()
 	webappRouter.Use(auth.MakeMiddleware(authDependency, auth.NewCSPMiddleware))
 	webappRouter.Use(auth.MakeMiddleware(authDependency, auth.NewCSRFMiddleware))
+	webappRouter.Use(webapp.PostNoCacheMiddleware)
 
 	webappAnonymousRouter := webappRouter.NewRoute().Subrouter()
 	webappAnonymousRouter.Use(webapp.RequiredAnonymousMiddleware{}.Handle)

--- a/pkg/auth/dependency/webapp/post_no_cache_middleware.go
+++ b/pkg/auth/dependency/webapp/post_no_cache_middleware.go
@@ -1,0 +1,16 @@
+package webapp
+
+import (
+	"net/http"
+)
+
+// PostNoCacheMiddleware makes every POST request non-cachable.
+func PostNoCacheMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Header().Set("Cache-Control", "no-store")
+			w.Header().Set("Pragma", "no-cache")
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/auth/dependency/webapp/template.go
+++ b/pkg/auth/dependency/webapp/template.go
@@ -185,20 +185,20 @@ var TemplateAuthUILoginHTML = template.Spec{
 				{{ end }}{{ end }}
 
 				{{ if .x_login_id_input_type }}{{ if and (eq .x_login_id_input_type "phone") .x_login_id_input_type_has_text }}
-				<button class="link anchor" type="submit" name="x_login_id_input_type" value="text" form="empty-form">Use an email or username instead</button>
+				<button class="link anchor align-self-flex-start" type="submit" name="x_login_id_input_type" value="text" form="empty-form">Use an email or username instead</button>
 				{{ end }}{{ end }}
 				{{ if .x_login_id_input_type }}{{ if and (not (eq .x_login_id_input_type "phone")) .x_login_id_input_type_has_phone }}
-				<button class="link anchor" type="submit" name="x_login_id_input_type" value="phone" form="empty-form">Use a phone number instead</button>
+				<button class="link anchor align-self-flex-start" type="submit" name="x_login_id_input_type" value="phone" form="empty-form">Use a phone number instead</button>
 				{{ end }}{{ end }}
 
 				<div class="link">
 					<span class="primary-text">Don't have an account yet? </span>
 					<button type="submit" class="anchor" name="x_step" value="signup:initial" form="empty-form">Create one!</button>
 				</div>
-				<a class="link anchor" href="#">Can't access your account?</a>
+				<a class="link anchor align-self-flex-start" href="#">Can't access your account?</a>
 
 				{{ if or .x_login_id_input_type_has_phone .x_login_id_input_type_has_text }}
-				<button class="btn primary-btn" type="submit" name="x_step" value="login:submit_login_id">Next</button>
+				<button class="btn primary-btn align-self-flex-end" type="submit" name="x_step" value="login:submit_login_id">Next</button>
 				{{ end }}
 			</form>
 		</div>
@@ -248,9 +248,9 @@ var TemplateAuthUILoginPasswordHTML = template.Spec{
 
 <button class="btn secondary-btn toggle-password-visibility"></button>
 
-<a class="anchor" href="">Forgot Password?</a>
+<a class="anchor align-self-flex-start" href="">Forgot Password?</a>
 
-<button class="btn primary-btn" type="submit" name="x_step" value="login:submit_password">Next</button>
+<button class="btn primary-btn align-self-flex-end" type="submit" name="x_step" value="login:submit_password">Next</button>
 
 </form>
 {{ template "SKYGEAR_LOGO" . }}
@@ -322,17 +322,17 @@ var TemplateAuthUISignupHTML = template.Spec{
 
 				{{ range .x_login_id_keys }}
 					{{ if not (eq .key $.x_login_id_key) }}
-					<button class="link anchor" type="submit" name="x_login_id_key" value="{{ .key }}" form="sign_up-{{ .key }}">Use {{ .key }} instead</button>
+					<button class="link anchor align-self-flex-start" type="submit" name="x_login_id_key" value="{{ .key }}" form="sign_up-{{ .key }}">Use {{ .key }} instead</button>
 					{{ end }}
 				{{ end }}
 
-				<div class="link">
+				<div class="link align-self-flex-start">
 					<span class="primary-text">Have an account already? </span>
 					<button type="submit" class="anchor" name="x_step" value="" form="empty-form">Sign in!</button>
 				</div>
-				<a class="link anchor" href="#">Can't access your account?</a>
+				<a class="link anchor align-self-flex-start" href="#">Can't access your account?</a>
 
-				<button class="btn primary-btn" type="submit" name="x_step" value="signup:submit_login_id">Next</button>
+				<button class="btn primary-btn align-self-flex-end" type="submit" name="x_step" value="signup:submit_login_id">Next</button>
 			</form>
 		</div>
 		{{ template "SKYGEAR_LOGO" . }}
@@ -423,7 +423,7 @@ var TemplateAuthUISignupPasswordHTML = template.Spec{
 </ul>
 {{ end }}
 
-<button class="btn primary-btn" type="submit" name="x_step" value="signup:submit_password">Next</button>
+<button class="btn primary-btn align-self-flex-end" type="submit" name="x_step" value="signup:submit_password">Next</button>
 
 {{ if eq .x_login_id_input_type "phone" }}
 <p class="description">
@@ -479,7 +479,7 @@ var TemplateAuthUILogoutHTML = template.Spec{
 <form class="logout-form" method="post">
   {{ $.csrfField }}
   <p>To logout, please click the button below.</p>
-  <button class="btn primary-btn logout-btn" type="submit" name="x_action" value="logout">Logout</button>
+  <button class="btn primary-btn align-self-center" type="submit" name="x_action" value="logout">Logout</button>
 </form>
 
 {{ template "SKYGEAR_LOGO" . }}

--- a/static/authui/css/main.css
+++ b/static/authui/css/main.css
@@ -27,6 +27,18 @@ select {
   -webkit-appearance: none;
 }
 
+.align-self-flex-start {
+  align-self: flex-start;
+}
+
+.align-self-flex-end {
+  align-self: flex-end;
+}
+
+.align-self-center {
+  align-self: center;
+}
+
 .primary-txt {
   color: #333333;
 }
@@ -194,10 +206,6 @@ button.anchor {
   padding: 4px 0;
 }
 
-.authorize-loginid-form .primary-btn[type="submit"] {
-  align-self: flex-end;
-}
-
 .authorize-loginid-form [name="x_calling_code"] {
   margin: 0 3px 0 0;
 }
@@ -297,10 +305,6 @@ button.anchor {
 
 .enter-password-form .toggle-password-visibility {
   margin: 0 0 20px 0;
-}
-
-.enter-password-form [type="submit"] {
-  align-self: flex-end;
 }
 
 .btn.toggle-password-visibility {


### PR DESCRIPTION
ref #1288

I cannot reproduce the original bug.

The first commit fixes a UX bug. Some links span the whole column but its text is very short. The user may mistakenly click on the blank area.

The second commit ensures POST request are not cache-able. Some POST requests contain login ID and password which should not be cached at all.