### PR TITLE
Rename OAuthPrincipalNotFound to OAuthIdentityNotFound

### DIFF
--- a/pkg/auth/handler/sso/unlink.go
+++ b/pkg/auth/handler/sso/unlink.go
@@ -26,7 +26,7 @@ import (
 	"github.com/skygeario/skygear-server/pkg/core/skyerr"
 )
 
-var errOauthPrincipalNotFound = skyerr.NotFound.WithReason("OAuthPrincipalNotFound").New("oauth principal not found")
+var errOauthIdentityNotFound = skyerr.NotFound.WithReason("OAuthIdentityNotFound").New("oauth identity not found")
 
 func AttachUnlinkHandler(
 	router *mux.Router,
@@ -119,7 +119,7 @@ func (h UnlinkHandler) Handle(r *http.Request) (resp interface{}, err error) {
 		})
 		if err != nil {
 			if errors.Is(err, principal.ErrNotFound) {
-				err = errOauthPrincipalNotFound
+				err = errOauthIdentityNotFound
 			}
 			return err
 		}

--- a/pkg/auth/handler/sso/unlink_test.go
+++ b/pkg/auth/handler/sso/unlink_test.go
@@ -212,9 +212,9 @@ func TestUnlinkHandler(t *testing.T) {
 			{
 				"error": {
 					"code": 404,
-					"message": "oauth principal not found",
+					"message": "oauth identity not found",
 					"name": "NotFound",
-					"reason": "OAuthPrincipalNotFound"
+					"reason": "OAuthIdentityNotFound"
 				}
 			}
 			`)


### PR DESCRIPTION
Reason is public API and we use the term Identity in public API.

fix #1316