### PR TITLE
Auth UI SSO login part 1

### DIFF
--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -258,6 +258,10 @@ func main() {
 	webapphandler.AttachSettingsHandler(webappAuthenticatedRouter, authDependency)
 	webapphandler.AttachLogoutHandler(webappAuthenticatedRouter, authDependency)
 
+	webappSSOCallbackRouter := rootRouter.NewRoute().Subrouter()
+	webappSSOCallbackRouter.Use(webapp.PostNoCacheMiddleware)
+	webapphandler.AttachSSOCallbackHandler(webappSSOCallbackRouter, authDependency)
+
 	if configuration.StaticAssetDir != "" {
 		rootRouter.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir(configuration.StaticAssetDir))))
 	}

--- a/pkg/auth/dependency/webapp/csrf.go
+++ b/pkg/auth/dependency/webapp/csrf.go
@@ -1,0 +1,3 @@
+package webapp
+
+const csrfCookieName = "_gorilla_csrf"

--- a/pkg/auth/dependency/webapp/csrf_middleware.go
+++ b/pkg/auth/dependency/webapp/csrf_middleware.go
@@ -16,7 +16,8 @@ func (m *CSRFMiddleware) Handle(next http.Handler) http.Handler {
 		[]byte(m.Key),
 		csrf.Path("/"),
 		csrf.Secure(!m.UseInsecureCookie),
-		csrf.SameSite(csrf.SameSiteLaxMode),
+		csrf.SameSite(csrf.SameSiteNoneMode),
+		csrf.CookieName(csrfCookieName),
 	)
 	return gorillaCSRF(next)
 }

--- a/pkg/auth/dependency/webapp/redirect.go
+++ b/pkg/auth/dependency/webapp/redirect.go
@@ -34,6 +34,10 @@ func RedirectToCurrentPath(w http.ResponseWriter, r *http.Request) {
 	RedirectToPathWithQueryPreserved(w, r, r.URL.Path)
 }
 
+func RedirectToPathWithQuery(w http.ResponseWriter, r *http.Request, path string, query url.Values) {
+	http.Redirect(w, r, NewURLWithPathAndQuery(path, query), http.StatusFound)
+}
+
 func getRedirectURI(r *http.Request) (out string, err error) {
 	out = r.URL.Query().Get("redirect_uri")
 	if out == "" {
@@ -111,4 +115,15 @@ func MakeURLWithQuery(u *url.URL, query url.Values) string {
 		q.Set(name, query.Get(name))
 	}
 	return fmt.Sprintf("?%s", q.Encode())
+}
+
+func NewURLWithPathAndQuery(path string, query url.Values) string {
+	u := url.URL{}
+	u.Path = path
+	q := u.Query()
+	for name := range query {
+		q.Set(name, query.Get(name))
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/pkg/auth/dependency/webapp/redirect.go
+++ b/pkg/auth/dependency/webapp/redirect.go
@@ -41,7 +41,12 @@ func getRedirectURI(r *http.Request) (out string, err error) {
 		return
 	}
 
-	u, err := r.URL.Parse(out)
+	out, err = parseRedirectURI(r, out)
+	return
+}
+
+func parseRedirectURI(r *http.Request, redirectURL string) (out string, err error) {
+	u, err := r.URL.Parse(redirectURL)
 	if err != nil {
 		return
 	}

--- a/pkg/auth/dependency/webapp/redirect_test.go
+++ b/pkg/auth/dependency/webapp/redirect_test.go
@@ -187,3 +187,17 @@ func TestMakeURLWithQuery(t *testing.T) {
 		test("http://example.com?c=d", "a", "b", "?a=b&c=d")
 	})
 }
+
+func TestNewURLWithPathAndQuery(t *testing.T) {
+	Convey("NewURLWithPathAndQuery", t, func() {
+		test := func(path string, name string, value string, expected string) {
+			actual := NewURLWithPathAndQuery(path, url.Values{
+				name: []string{value},
+			})
+			So(actual, ShouldEqual, expected)
+		}
+
+		test("/login", "a", "b c", "/login?a=b+c")
+		test("/", "a", "b", "/?a=b")
+	})
+}

--- a/pkg/auth/dependency/webapp/sso_state.go
+++ b/pkg/auth/dependency/webapp/sso_state.go
@@ -1,0 +1,14 @@
+package webapp
+
+type SSOState map[string]string
+
+func (c SSOState) CallbackURL() string {
+	if s, ok := c["callback_url"]; ok {
+		return s
+	}
+	return ""
+}
+
+func (c SSOState) SetCallbackURL(s string) {
+	c["callback_url"] = s
+}

--- a/pkg/auth/dependency/webapp/sso_state.go
+++ b/pkg/auth/dependency/webapp/sso_state.go
@@ -12,3 +12,14 @@ func (c SSOState) CallbackURL() string {
 func (c SSOState) SetCallbackURL(s string) {
 	c["callback_url"] = s
 }
+
+func (c SSOState) WebAppStateID() string {
+	if s, ok := c["webapp_sid"]; ok {
+		return s
+	}
+	return ""
+}
+
+func (c SSOState) SetWebAppStateID(s string) {
+	c["webapp_sid"] = s
+}

--- a/pkg/auth/dependency/webapp/sso_state.go
+++ b/pkg/auth/dependency/webapp/sso_state.go
@@ -2,24 +2,13 @@ package webapp
 
 type SSOState map[string]string
 
-func (c SSOState) CallbackURL() string {
-	if s, ok := c["callback_url"]; ok {
+func (c SSOState) RequestQuery() string {
+	if s, ok := c["request_query"]; ok {
 		return s
 	}
 	return ""
 }
 
-func (c SSOState) SetCallbackURL(s string) {
-	c["callback_url"] = s
-}
-
-func (c SSOState) WebAppStateID() string {
-	if s, ok := c["webapp_sid"]; ok {
-		return s
-	}
-	return ""
-}
-
-func (c SSOState) SetWebAppStateID(s string) {
-	c["webapp_sid"] = s
+func (c SSOState) SetRequestQuery(s string) {
+	c["request_query"] = s
 }

--- a/pkg/auth/dependency/webapp/validate_provider_impl.go
+++ b/pkg/auth/dependency/webapp/validate_provider_impl.go
@@ -18,6 +18,7 @@ func init() {
 		SignupRequestSchema,
 		SignupLoginIDRequestSchema,
 		SignupLoginIDPasswordRequestSchema,
+		SSOCallbackRequestSchema,
 	)
 }
 
@@ -158,6 +159,19 @@ const SignupLoginIDPasswordRequestSchema = `
 			"required": ["x_login_id"]
 		}
 	]
+}
+`
+
+const SSOCallbackRequestSchema = `
+{
+	"$id": "#SSOCallbackRequest",
+	"type": "object",
+	"properties": {
+		"state": { "type": "string" },
+		"code": { "type": "string" },
+		"scope": { "type": "string" }
+	},
+	"required": ["state", "code"]
 }
 `
 

--- a/pkg/auth/handler/webapp/login.go
+++ b/pkg/auth/handler/webapp/login.go
@@ -26,7 +26,7 @@ func AttachLoginHandler(
 
 func redirectURIForWebApp(urlPrefix *url.URL, providerConfig config.OAuthProviderConfiguration) string {
 	u := *urlPrefix
-	u.Path = path.Join(u.Path, fmt.Sprintf("sso/%s/callback", url.PathEscape(providerConfig.ID)))
+	u.Path = path.Join(u.Path, fmt.Sprintf("sso/oauth2/callback/%s", url.PathEscape(providerConfig.ID)))
 	return u.String()
 }
 

--- a/pkg/auth/handler/webapp/login.go
+++ b/pkg/auth/handler/webapp/login.go
@@ -1,11 +1,16 @@
 package webapp
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
+	"path"
 
 	"github.com/gorilla/mux"
 
 	"github.com/skygeario/skygear-server/pkg/auth"
+	"github.com/skygeario/skygear-server/pkg/auth/dependency/webapp"
+	"github.com/skygeario/skygear-server/pkg/core/config"
 )
 
 func AttachLoginHandler(
@@ -19,13 +24,21 @@ func AttachLoginHandler(
 		Handler(auth.MakeHandler(authDependency, newLoginHandler))
 }
 
+func redirectURIForWebApp(urlPrefix *url.URL, providerConfig config.OAuthProviderConfiguration) string {
+	u := *urlPrefix
+	u.Path = path.Join(u.Path, fmt.Sprintf("sso/%s/callback", url.PathEscape(providerConfig.ID)))
+	return u.String()
+}
+
 type loginProvider interface {
 	GetLoginForm(w http.ResponseWriter, r *http.Request) (func(error), error)
 	PostLoginID(w http.ResponseWriter, r *http.Request) (func(error), error)
+	ChooseIdentityProvider(w http.ResponseWriter, r *http.Request, oauthProvider webapp.OAuthProvider) (func(error), error)
 }
 
 type LoginHandler struct {
-	Provider loginProvider
+	Provider      loginProvider
+	oauthProvider webapp.OAuthProvider
 }
 
 func (h *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -41,6 +54,16 @@ func (h *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == "POST" {
+		if r.Form.Get("x_idp_id") != "" {
+			if h.oauthProvider == nil {
+				http.Error(w, "Not found", http.StatusNotFound)
+				return
+			}
+			writeResponse, err := h.Provider.ChooseIdentityProvider(w, r, h.oauthProvider)
+			writeResponse(err)
+			return
+		}
+
 		writeResponse, err := h.Provider.PostLoginID(w, r)
 		writeResponse(err)
 		return

--- a/pkg/auth/handler/webapp/sso_callback.go
+++ b/pkg/auth/handler/webapp/sso_callback.go
@@ -15,7 +15,7 @@ func AttachSSOCallbackHandler(
 ) {
 	router.
 		NewRoute().
-		Path("/sso/{provider}/callback").
+		Path("/sso/oauth2/callback/{provider}").
 		Methods("OPTIONS", "GET", "POST").
 		Handler(auth.MakeHandler(authDependency, newSSOCallbackHandler))
 }

--- a/pkg/auth/handler/webapp/sso_callback.go
+++ b/pkg/auth/handler/webapp/sso_callback.go
@@ -1,0 +1,43 @@
+package webapp
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/skygeario/skygear-server/pkg/auth"
+	"github.com/skygeario/skygear-server/pkg/auth/dependency/webapp"
+)
+
+func AttachSSOCallbackHandler(
+	router *mux.Router,
+	authDependency auth.DependencyMap,
+) {
+	router.
+		NewRoute().
+		Path("/sso/{provider}/callback").
+		Methods("OPTIONS", "GET", "POST").
+		Handler(auth.MakeHandler(authDependency, newSSOCallbackHandler))
+}
+
+type ssoProvider interface {
+	HandleSSOCallback(w http.ResponseWriter, r *http.Request, oauthProvider webapp.OAuthProvider) (func(error), error)
+}
+
+type SSOCallbackHandler struct {
+	Provider      ssoProvider
+	oauthProvider webapp.OAuthProvider
+}
+
+func (h *SSOCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if h.oauthProvider == nil {
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
+	writeResponse, err := h.Provider.HandleSSOCallback(w, r, h.oauthProvider)
+	writeResponse(err)
+}

--- a/pkg/auth/handler/webapp/wire_gen.go
+++ b/pkg/auth/handler/webapp/wire_gen.go
@@ -7,6 +7,7 @@ package webapp
 
 import (
 	"github.com/google/wire"
+	"github.com/gorilla/mux"
 	"github.com/skygeario/skygear-server/pkg/auth"
 	"github.com/skygeario/skygear-server/pkg/auth/dependency/audit"
 	auth2 "github.com/skygeario/skygear-server/pkg/auth/dependency/auth"
@@ -116,13 +117,13 @@ func newLoginHandler(r *http.Request, m auth.DependencyMap) http.Handler {
 	stateStoreImpl := &webapp.StateStoreImpl{
 		Context: context,
 	}
-	ssoProvider := sso.ProvideSSOProvider(context, tenantConfiguration)
+	provider2 := sso.ProvideSSOProvider(context, tenantConfiguration)
 	authenticateProviderImpl := &webapp.AuthenticateProviderImpl{
 		ValidateProvider: validateProvider,
 		RenderProvider:   renderProvider,
 		AuthnProvider:    authnProvider,
 		StateStore:       stateStoreImpl,
-		SSOProvider:      ssoProvider,
+		SSOProvider:      provider2,
 	}
 	loginIDNormalizerFactory := loginid.ProvideLoginIDNormalizerFactory(tenantConfiguration)
 	redirectURLFunc := provideRedirectURIForWebAppFunc()
@@ -212,13 +213,13 @@ func newLoginPasswordHandler(r *http.Request, m auth.DependencyMap) http.Handler
 	stateStoreImpl := &webapp.StateStoreImpl{
 		Context: context,
 	}
-	ssoProvider := sso.ProvideSSOProvider(context, tenantConfiguration)
+	provider2 := sso.ProvideSSOProvider(context, tenantConfiguration)
 	authenticateProviderImpl := &webapp.AuthenticateProviderImpl{
 		ValidateProvider: validateProvider,
 		RenderProvider:   renderProvider,
 		AuthnProvider:    authnProvider,
 		StateStore:       stateStoreImpl,
-		SSOProvider:      ssoProvider,
+		SSOProvider:      provider2,
 	}
 	loginPasswordHandler := &LoginPasswordHandler{
 		Provider: authenticateProviderImpl,
@@ -299,13 +300,13 @@ func newSignupHandler(r *http.Request, m auth.DependencyMap) http.Handler {
 	stateStoreImpl := &webapp.StateStoreImpl{
 		Context: context,
 	}
-	ssoProvider := sso.ProvideSSOProvider(context, tenantConfiguration)
+	provider2 := sso.ProvideSSOProvider(context, tenantConfiguration)
 	authenticateProviderImpl := &webapp.AuthenticateProviderImpl{
 		ValidateProvider: validateProvider,
 		RenderProvider:   renderProvider,
 		AuthnProvider:    authnProvider,
 		StateStore:       stateStoreImpl,
-		SSOProvider:      ssoProvider,
+		SSOProvider:      provider2,
 	}
 	signupHandler := &SignupHandler{
 		Provider: authenticateProviderImpl,
@@ -386,13 +387,13 @@ func newSignupPasswordHandler(r *http.Request, m auth.DependencyMap) http.Handle
 	stateStoreImpl := &webapp.StateStoreImpl{
 		Context: context,
 	}
-	ssoProvider := sso.ProvideSSOProvider(context, tenantConfiguration)
+	provider2 := sso.ProvideSSOProvider(context, tenantConfiguration)
 	authenticateProviderImpl := &webapp.AuthenticateProviderImpl{
 		ValidateProvider: validateProvider,
 		RenderProvider:   renderProvider,
 		AuthnProvider:    authnProvider,
 		StateStore:       stateStoreImpl,
-		SSOProvider:      ssoProvider,
+		SSOProvider:      provider2,
 	}
 	signupPasswordHandler := &SignupPasswordHandler{
 		Provider: authenticateProviderImpl,
@@ -463,6 +464,98 @@ func newLogoutHandler(r *http.Request, m auth.DependencyMap) http.Handler {
 	return logoutHandler
 }
 
+func newSSOCallbackHandler(r *http.Request, m auth.DependencyMap) http.Handler {
+	context := auth.ProvideContext(r)
+	tenantConfiguration := auth.ProvideTenantConfig(context)
+	validateProvider := webapp.ProvideValidateProvider(tenantConfiguration)
+	engine := auth.ProvideTemplateEngine(tenantConfiguration, m)
+	provider := time.NewProvider()
+	sqlBuilderFactory := db.ProvideSQLBuilderFactory(tenantConfiguration)
+	sqlBuilder := auth.ProvideAuthSQLBuilder(sqlBuilderFactory)
+	sqlExecutor := db.ProvideSQLExecutor(context, tenantConfiguration)
+	store := pq.ProvidePasswordHistoryStore(provider, sqlBuilder, sqlExecutor)
+	passwordChecker := audit.ProvidePasswordChecker(tenantConfiguration, store)
+	renderProvider := auth.ProvideWebAppRenderProvider(m, tenantConfiguration, engine, passwordChecker)
+	requestID := auth.ProvideLoggingRequestID(r)
+	factory := logging.ProvideLoggerFactory(context, requestID, tenantConfiguration)
+	reservedNameChecker := auth.ProvideReservedNameChecker(m)
+	passwordProvider := password.ProvidePasswordProvider(sqlBuilder, sqlExecutor, provider, store, factory, tenantConfiguration, reservedNameChecker)
+	oauthProvider := oauth.ProvideOAuthProvider(sqlBuilder, sqlExecutor)
+	v := auth.ProvidePrincipalProviders(oauthProvider, passwordProvider)
+	identityProvider := principal.ProvideIdentityProvider(sqlBuilder, sqlExecutor, v)
+	authenticateProcess := authn.ProvideAuthenticateProcess(factory, provider, passwordProvider, oauthProvider, identityProvider)
+	loginIDChecker := loginid.ProvideLoginIDChecker(tenantConfiguration, reservedNameChecker)
+	authinfoStore := pq2.ProvideStore(sqlBuilderFactory, sqlExecutor)
+	userprofileStore := userprofile.ProvideStore(provider, sqlBuilder, sqlExecutor)
+	txContext := db.ProvideTxContext(context, tenantConfiguration)
+	hookProvider := hook.ProvideHookProvider(context, sqlBuilder, sqlExecutor, requestID, tenantConfiguration, txContext, provider, authinfoStore, userprofileStore, passwordProvider, factory)
+	urlprefixProvider := urlprefix.NewProvider(r)
+	executor := auth.ProvideTaskExecutor(m)
+	queue := async.ProvideTaskQueue(context, txContext, requestID, tenantConfiguration, executor)
+	signupProcess := authn.ProvideSignupProcess(passwordChecker, loginIDChecker, identityProvider, passwordProvider, oauthProvider, provider, authinfoStore, userprofileStore, hookProvider, tenantConfiguration, urlprefixProvider, queue)
+	oAuthCoordinator := &authn.OAuthCoordinator{
+		Authn:  authenticateProcess,
+		Signup: signupProcess,
+	}
+	mfaStore := pq3.ProvideStore(tenantConfiguration, sqlBuilder, sqlExecutor, provider)
+	client := sms.ProvideSMSClient(context, tenantConfiguration)
+	sender := mail.ProvideMailSender(context, tenantConfiguration)
+	mfaSender := mfa.ProvideMFASender(tenantConfiguration, client, sender, engine)
+	mfaProvider := mfa.ProvideMFAProvider(mfaStore, tenantConfiguration, provider, mfaSender)
+	sessionStore := redis.ProvideStore(context, tenantConfiguration, provider, factory)
+	eventStore := redis2.ProvideEventStore(context, tenantConfiguration)
+	accessEventProvider := &auth2.AccessEventProvider{
+		Store: eventStore,
+	}
+	sessionProvider := session.ProvideSessionProvider(r, sessionStore, accessEventProvider, tenantConfiguration)
+	authorizationStore := &pq4.AuthorizationStore{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	grantStore := redis3.ProvideGrantStore(context, factory, tenantConfiguration, sqlBuilder, sqlExecutor, provider)
+	authAccessEventProvider := auth2.AccessEventProvider{
+		Store: eventStore,
+	}
+	idTokenIssuer := oidc.ProvideIDTokenIssuer(tenantConfiguration, urlprefixProvider, authinfoStore, userprofileStore, identityProvider, provider)
+	tokenGenerator := _wireTokenGeneratorValue
+	tokenHandler := handler.ProvideTokenHandler(r, tenantConfiguration, factory, authorizationStore, grantStore, grantStore, grantStore, authAccessEventProvider, sessionProvider, idTokenIssuer, tokenGenerator, provider)
+	authnSessionProvider := authn.ProvideSessionProvider(mfaProvider, sessionProvider, tenantConfiguration, provider, authinfoStore, userprofileStore, identityProvider, hookProvider, tokenHandler)
+	insecureCookieConfig := auth.ProvideSessionInsecureCookieConfig(m)
+	cookieConfiguration := session.ProvideSessionCookieConfiguration(r, insecureCookieConfig, tenantConfiguration)
+	mfaInsecureCookieConfig := auth.ProvideMFAInsecureCookieConfig(m)
+	bearerTokenCookieConfiguration := mfa.ProvideBearerTokenCookieConfiguration(r, mfaInsecureCookieConfig, tenantConfiguration)
+	providerFactory := &authn.ProviderFactory{
+		OAuth:                   oAuthCoordinator,
+		Authn:                   authenticateProcess,
+		Signup:                  signupProcess,
+		AuthnSession:            authnSessionProvider,
+		Session:                 sessionProvider,
+		SessionCookieConfig:     cookieConfiguration,
+		BearerTokenCookieConfig: bearerTokenCookieConfiguration,
+	}
+	authnProvider := authn.ProvideAuthUIProvider(providerFactory)
+	stateStoreImpl := &webapp.StateStoreImpl{
+		Context: context,
+	}
+	provider2 := sso.ProvideSSOProvider(context, tenantConfiguration)
+	authenticateProviderImpl := &webapp.AuthenticateProviderImpl{
+		ValidateProvider: validateProvider,
+		RenderProvider:   renderProvider,
+		AuthnProvider:    authnProvider,
+		StateStore:       stateStoreImpl,
+		SSOProvider:      provider2,
+	}
+	loginIDNormalizerFactory := loginid.ProvideLoginIDNormalizerFactory(tenantConfiguration)
+	redirectURLFunc := provideRedirectURIForWebAppFunc()
+	oAuthProviderFactory := sso.ProvideOAuthProviderFactory(tenantConfiguration, urlprefixProvider, provider, loginIDNormalizerFactory, redirectURLFunc)
+	oAuthProvider := provideOAuthProviderFromRequestVars(r, oAuthProviderFactory)
+	ssoCallbackHandler := &SSOCallbackHandler{
+		Provider:      authenticateProviderImpl,
+		oauthProvider: oAuthProvider,
+	}
+	return ssoCallbackHandler
+}
+
 // wire.go:
 
 var authDepSet = wire.NewSet(authn.ProvideAuthUIProvider, wire.Bind(new(webapp.AuthnProvider), new(*authn.Provider)), wire.Struct(new(webapp.AuthenticateProviderImpl), "*"))
@@ -474,4 +567,9 @@ func provideRedirectURIForWebAppFunc() sso.RedirectURLFunc {
 func provideOAuthProviderFromLoginForm(r *http.Request, spf *sso.OAuthProviderFactory) sso.OAuthProvider {
 	idp := r.Form.Get("x_idp_id")
 	return spf.NewOAuthProvider(idp)
+}
+
+func provideOAuthProviderFromRequestVars(r *http.Request, spf *sso.OAuthProviderFactory) sso.OAuthProvider {
+	vars := mux.Vars(r)
+	return spf.NewOAuthProvider(vars["provider"])
 }


### PR DESCRIPTION
require #1331 
connect #1320 

The pr only covers login with general sso login, tested with google login only.

Question:
- Now when there is error in the sso flow, we redirect user back to login page. Maybe we should update the error display to a more generic place? Currently it shows above the login id form

TODO:
- Login with apple flow should be different? Will further study.
- Link with sso provider, the connect buttons should be appear in the settings page