### PR TITLE
Add back unique constraint to login id identity table

### DIFF
--- a/migrations/auth/1588670460_add_login_id_unique_key_constraint.down.sql
+++ b/migrations/auth/1588670460_add_login_id_unique_key_constraint.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE _auth_identity_login_id DROP CONSTRAINT _auth_identity_login_id_unique_key;

--- a/migrations/auth/1588670460_add_login_id_unique_key_constraint.up.sql
+++ b/migrations/auth/1588670460_add_login_id_unique_key_constraint.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE _auth_identity_login_id ADD CONSTRAINT _auth_identity_login_id_unique_key UNIQUE(app_id, unique_key);


### PR DESCRIPTION
We had unique index to app_id, realm and unique_key columns, the index was dropped when we deleted realm column. Add back the unique index to app_id and unique_key.