### PR TITLE
Handle IPv4 and IPv6 in CookieDomainFromETLDPlusOneWithoutPort

### DIFF
--- a/pkg/core/http/cookie.go
+++ b/pkg/core/http/cookie.go
@@ -3,6 +3,7 @@ package http
 import (
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"golang.org/x/net/publicsuffix"
@@ -91,9 +92,22 @@ func CookieDomainFromETLDPlusOneWithoutPort(host string) string {
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
 	}
+
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		ipv6Str := host[1 : len(host)-1]
+		if ipv6 := net.ParseIP(ipv6Str); ipv6 != nil {
+			return ""
+		}
+	}
+
+	if ipv4or6 := net.ParseIP(host); ipv4or6 != nil {
+		return ""
+	}
+
 	host, err := publicsuffix.EffectiveTLDPlusOne(host)
 	if err != nil {
 		return ""
 	}
+
 	return host
 }

--- a/pkg/core/http/cookie_test.go
+++ b/pkg/core/http/cookie_test.go
@@ -111,6 +111,13 @@ func TestCookieDomainFromETLDPlusOneWithoutPort(t *testing.T) {
 			So(out, ShouldEqual, actual)
 		}
 		check("localhost", "")
+		check("localhost:3000", "")
+
+		check("[::1]:3000", "")
+		check("[::1]", "")
+
+		check("10.0.2.2:3000", "")
+		check("10.0.2.2", "")
 
 		check("accounts.localhost", "accounts.localhost")
 		check("accounts.localhost:8081", "accounts.localhost")


### PR DESCRIPTION
fix #1415 