### PR TITLE
Register challenge schema

### DIFF
--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -100,6 +100,9 @@ func main() {
 	}
 
 	validator := validation.NewValidator("http://v2.skgyear.io")
+	validator.AddSchemaFragments(
+		oauthhandler.ChallengeRequestSchema,
+	)
 
 	dbPool := db.NewPool()
 	redisPool, err := redis.NewPool(configuration.Redis)


### PR DESCRIPTION
fix #1459

Actually a static validator instance for each endpoint is better than a global validator that we have to register schema in main.go. But let's address that in another issue.